### PR TITLE
v1.0.2: Local Fresh categories, Plan Mode for both engines, page-context snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.0.2 — 2026-06-01
+
+### Added
+- **Local AI engine now honours the "When AI creates a new group" dropdown** with all three behaviours: Auto-add, Transient, Fresh categories (previously Ollama-only).
+- **Local Fresh mode.** Clusters every tab into new hostname/intent-named groups using the bundled embedding model.
+- **Plan Mode (identify-only) modal now works for the Local engine**, not just Ollama.
+- **Page-context snippets** (`og:type`, `og:site_name`, first `h1`, description) are now fetched and fed to both engines for better classification.
+- **3rd-phase fuzzy name dedupe for Ollama Fresh.** Catches near-duplicate cluster names like "Content Unavailable" + "Content Unavailability" or "Communication Apps" + "Communication Tools".
+- **Stickiness in Ollama unified mode.** Tabs already in an existing group can't be pulled into brand-new AI-invented groups — only into other existing groups.
+- **Skip Domains** setting (carry-over polish on top of 1.0.1's section).
+- **Strict rule enforcement** option that ejects tabs from a group when their hostname isn't listed in that group's rule.
+- **Drag-handle reorder** of rules in the settings rules editor.
+- **Right-click "Dissolve group"** on tab-groups; **"Add to Rule…" submenu** on tabs.
+- **Collapsed-group state persists across browser restarts.**
+- **Chunking + hostname-dedupe for Local AI** on workspaces with >75 unmatched tabs. Configurable batch size; soft-cap confirmation modal at >500 tabs.
+- **First-time warning modal** when selecting the Ollama or Local AI engine (fires once per engine).
+- **README "Choosing an AI model" table** with qwen2.5 size variants.
+
+### Changed
+- **Ollama generate timeout raised from 60s → 180s.** Accommodates qwen2.5:7b classifying 100+ unique tabs in one pass.
+- **Unified-classifier prompt** now carries an explicit anti-catch-all instruction so the model stops dumping unrelated tabs into a generic existing rule like "Utils".
+
+### Fixed
+- **Auto-sort into a collapsed group.** Target group now re-collapses correctly and the newly-added tabs are properly `aria-hidden`.
+- **Collapse state survives session restore.** Zen's session save drops the `collapsed` attribute; we re-apply it from a persisted pref on workspace load.
+- **In-progress rules with no domains yet** now survive a browser restart and show up in the right-click "Add to Rule…" submenu.
+
 ## 1.0.1 — 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ The tab doesn't move — only the rule grows. Click the wand afterwards to actua
 | Engine | What it does | Setup |
 |---|---|---|
 | **Off** | Rules only. Tabs without a matching rule stay where they are. | — |
-| **Local** | Firefox's bundled tab-embedding model. Only assigns tabs to *existing* groups; conservative by design, no new groups. No setup. | None — built in. |
-| **Ollama** | A local Ollama daemon. Can both assign tabs into existing groups AND invent new ones, with a merge pass and an optional interactive **Plan Mode** modal where you preview the AI's plan before applying. | Install [Ollama](https://ollama.com), then `ollama pull qwen2.5:1.5b` (or a bigger model if you have the VRAM). |
+| **Local** | Firefox's bundled tab-embedding model. Assigns tabs to existing groups and — as of v1.0.2 — can also invent new groups (Auto-add / Transient / Fresh categories). Names are derived from hostnames, intent labels, or extracted keywords. No setup. | None — built in. |
+| **Ollama** | A local Ollama daemon. Assigns tabs into existing groups and invents new ones, with a merge pass and an optional interactive **Plan Mode** where you preview the plan before applying. | Install [Ollama](https://ollama.com), then `ollama pull qwen2.5:1.5b` (or a bigger model if you have the VRAM). |
+
+The first time you pick **Local** or **Ollama** in settings, a one-shot warning modal explains the resource cost (CPU/RAM for Local, VRAM for Ollama) and asks you to acknowledge before the engine is allowed to run.
+
+Both engines fetch a small page-context snippet (`og:type`, `og:site_name`, first `<h1>`, `<meta name="description">`) for each unmatched tab to classify on more than just the URL.
 
 For Ollama, the default model is `qwen2.5:1.5b` (~1 GB, runs on most GPUs). If you have 8+ GB VRAM, `qwen2.5:7b` is noticeably more accurate — change the model name in settings.
 
@@ -97,26 +101,52 @@ Ollama runs entirely on your machine — no API keys, no cloud, no per-token cos
 
 If you have questions about Ollama itself (other models, GPU compatibility, remote hosts, etc.) head to the [Ollama project site](https://ollama.com) and its [GitHub README](https://github.com/ollama/ollama).
 
+## Choosing an AI model
+
+The mod ships with two engines and lets you pick any model your Ollama install can run.
+
+| Engine / model | Size on disk | What it can do | System impact |
+|---|---|---|---|
+| **Local** (`Mozilla/smart-tab-embedding`, built in) | ~100 MB | Assigns tabs to existing groups only. No new categories. | Light, CPU only |
+| `qwen2.5:0.5b` | ~400 MB | Basic clustering. Vague names. | Tiny, ~500 MB VRAM |
+| `qwen2.5:1.5b` (default) | ~1 GB | Decent clustering, simple names. | Small, ~1.5 GB VRAM |
+| `qwen2.5:3b` | ~2 GB | Better naming and category logic. | Medium, ~3 GB VRAM |
+| `qwen2.5:7b` | ~5 GB | Strong naming and merging. Recommended. | Mid, ~6-8 GB VRAM |
+| `qwen2.5:14b` | ~10 GB | Excellent on ambiguous tabs. | High, ~12 GB VRAM |
+| `qwen2.5:32b` | ~22 GB | Best quality. Diminishing returns vs 14b. | Workstation, 24+ GB VRAM |
+
 ## Modes when AI creates a new group
 
-(Only relevant when the AI engine is set to Ollama.)
+Applies to both engines. The Local engine supports **Auto-add**, **Transient**, and **Fresh categories**; Ollama supports all five.
 
 | Mode | What happens |
 |---|---|
-| **Auto-add** | AI creates the group AND saves a rule with the tabs' hostnames. Rules grow over time. Modal asks you to confirm. |
+| **Auto-add** | AI creates the group AND saves a rule with the tabs' hostnames. Rules grow over time. Ollama shows a confirmation modal; Local applies directly. |
 | **Transient** | AI creates the group, no rule saved. Fast, no confirmation. |
-| **Prompt** | Opens Zen's edit modal for each new group so you can rename/recolor. |
-| **Fresh categories** | AI re-tidies **all** tabs into fresh categories, ignoring your rules. Like Arc Browser's Tidy. |
-| **Plan Mode** | Shows the proposed plan in a modal first. You toggle each group keep/skip, optionally click "Re-assign" to redo the unkept tabs, then Apply. |
+| **Prompt** (Ollama only) | Opens Zen's edit modal for each new group so you can rename/recolor. |
+| **Fresh categories** | Re-tidies **all** tabs into fresh categories, ignoring your rules. Like Arc Browser's Tidy. Local Fresh names clusters from a shared hostname (e.g. `Github & Gitlab`), an intent label (e.g. `Reading`), or extracted keywords (e.g. `Yu-Gi-Oh`) depending on the strongest signal in the cluster. Ollama Fresh runs a third-phase fuzzy-name dedupe that catches near-duplicates like `Content Unavailable` + `Content Unavailability`. |
+| **Plan Mode** (Ollama only) | Shows the proposed plan in a modal first. You toggle each group keep/skip, optionally click "Re-assign" to redo the unkept tabs into your existing groups, then Apply. |
 
 ![Plan Mode modal](docs/images/plan-mode-modal.png)
 
+### Stickiness in Auto-add / Always-add
+
+In Ollama **Auto-add** (new group) and **Always-add** (existing group) modes, tabs already sitting in a group you organized by hand won't be pulled out into a brand-new AI-invented group. They can still move into another *existing* group if the AI is confident. This keeps your manual organization from getting churned every time you click the wand.
+
 ## Other settings
 
-- **Skip Domains** — a list of hostnames the wand should never touch. Tabs matching any pattern get ejected from any group and parked at the top of the workspace on every click. Useful for tabs you want to always keep visible and ungrouped.
+- **Skip Domains** — a list of hostnames the wand should never touch. Tabs matching any pattern get ejected from any group and parked at the top of the workspace on every click. Useful for tabs you want to always keep visible and ungrouped. Grow the list from a tab right-click → **Add "host" to Rule…** → **Skip**.
 - **Strict rule enforcement** — when on, tabs sitting inside a group whose rule doesn't list their hostname get ejected to the top on every wand click. Off by default.
 - **Minimal style** — strips the colored backgrounds from groups for a flatter look.
 - **Keep Ollama model warm** — preloads the model at browser startup and keeps it in VRAM between clicks. Faster, but uses VRAM continuously.
+- **Local AI batch size** — only used when there are more than 75 unmatched tabs. The Local engine switches into a chunked pipeline that dedupes by hostname (one embedding per unique domain) and yields between batches so the browser stays responsive. Smaller batches = gentler on CPU, larger = faster. Above 500 unmatched tabs a confirmation modal appears before the AI pass runs.
+- **Rule reordering** — drag the handle on the left of any row in the Group Rules table to reorder rules. Order determines match priority when a hostname appears in more than one rule.
+- **Persistent collapsed groups** — collapsed/expanded state of every tab-group is saved and re-applied across browser restarts (Zen's own session save drops this).
+
+## Right-click menus
+
+- **On a tab** — `Add "host" to Rule…` opens a submenu listing every current rule plus a **Skip** entry. Rules already containing the hostname show a checkmark and are disabled.
+- **On a tab-group header** — `Dissolve group` removes the group container and leaves its tabs in place at the top of the workspace. Useful when an AI-invented group missed the mark.
 
 ## Backup & Restore
 

--- a/auto-organize.uc.mjs
+++ b/auto-organize.uc.mjs
@@ -3,7 +3,7 @@
 // window) and `about:preferences*` (the settings page). Branches on window.location
 // to wire the right submodules in each context.
 
-import { CONFIG, LOG } from "./modules/config.mjs";
+import { CONFIG, LOG, BUILD_VERSION } from "./modules/config.mjs";
 import { domCache } from "./modules/tabs.mjs";
 import { readRulesPref, getAIEngine, getOllamaHost, getOllamaModel, isOllamaWarmupEnabled } from "./modules/rules.mjs";
 import { syncAllGroupColors } from "./modules/groups.mjs";
@@ -16,7 +16,10 @@ import {
 import {
   setupTabContextMenu,
   teardownTabContextMenu,
+  setupTabGroupContextMenu,
+  teardownTabGroupContextMenu,
   setupTabGroupCreateHook,
+  setupCollapsedStatePersistence,
   setupMinimalStylePrefObserver,
   teardownMinimalStylePrefObserver,
 } from "./modules/browser-hooks.mjs";
@@ -43,7 +46,9 @@ const tryInitializeBrowser = () => {
       addButtonToAllSeparators();
       setupWorkspaceHooks();
       setupTabContextMenu();
+      setupTabGroupContextMenu();
       setupTabGroupCreateHook();
+      setupCollapsedStatePersistence();
       setupMinimalStylePrefObserver();
 
       // Apply colors to groups that were restored before our hook installed
@@ -62,7 +67,7 @@ const tryInitializeBrowser = () => {
         warmupOllama(getOllamaHost(), getOllamaModel());
       }
 
-      console.log(`${LOG} initialized (browser)`);
+      console.log(`${LOG} initialized (browser) — build ${BUILD_VERSION}`);
       return true;
     }
   } catch (e) {
@@ -103,6 +108,7 @@ const cleanup = () => {
     domCache.invalidate();
     teardownSettingsObserver();
     teardownTabContextMenu();
+    teardownTabGroupContextMenu();
     teardownMinimalStylePrefObserver();
   } catch (e) {
     console.error(`${LOG} cleanup error:`, e);

--- a/modules/ai.mjs
+++ b/modules/ai.mjs
@@ -25,8 +25,9 @@ import {
   writeRulesPref,
   getAIExistingBehavior,
   getAINewGroupBehavior,
+  getLocalAIBatchSize,
 } from "./rules.mjs";
-import { getTabTitle } from "./tabs.mjs";
+import { getTabTitle, fetchPageSnippet } from "./tabs.mjs";
 import { findExistingGroup, expandIfCollapsed, applyGroupColor, findSafeInsertAnchor } from "./groups.mjs";
 import { showToast } from "./ui-toast.mjs";
 
@@ -127,26 +128,77 @@ const buildEmbedText = (titleOrInfo) => {
   return title;
 };
 
+// Cap on what we send to the embedder. Mozilla's smart-tab-embedding has an
+// internal token limit; we truncate at ~1000 chars (well under any reasonable
+// token cap, but generous enough to fit title + hostname + rich snippet).
+const MAX_EMBED_INPUT_CHARS = 1000;
+
+// The MLEngineParent port can die between clicks (Firefox tears it down when
+// the engine pref flips, or when memory pressure kicks in). When that happens
+// the cached `embeddingEnginePromise` still resolves to a dead engine whose
+// `.run()` throws "Port does not exist" for every call. This sentinel lets
+// embed() report the dead-port case to embedBatch so it can invalidate the
+// cache and retry the whole batch once.
+const DEAD_PORT_SENTINEL = Symbol("dead-port");
+
 const embed = async (input) => {
-  const text = buildEmbedText(input);
+  let text = buildEmbedText(input);
   if (!text || typeof text !== "string") return null;
+  if (text.length > MAX_EMBED_INPUT_CHARS) text = text.slice(0, MAX_EMBED_INPUT_CHARS);
   try {
     const engine = await loadEmbeddingEngine();
     const result = await engine.run({ args: [text] });
     const pooled = poolEmbedding(result);
     return pooled ? l2Normalize(pooled) : null;
   } catch (e) {
+    const msg = String(e?.message || e);
+    if (msg.includes("Port does not exist")) {
+      // Don't log noise here — embedBatch logs once per dead-port batch.
+      return DEAD_PORT_SENTINEL;
+    }
     console.error(`${LOG} embedding failed for "${text}":`, e);
     return null;
   }
 };
 
-const embedBatch = async (inputs) => {
+// Embed an array of {title, hostname} inputs in chunks.
+//
+// `opts.batchSize` overrides the default chunk width. `opts.yieldBetween`
+// inserts an `await setTimeout(0)` after each chunk so the event loop stays
+// responsive — used on the large-workspace path (>75 unmatched tabs) where
+// without yielding the browser tab can freeze for many seconds.
+//
+// Dead-engine recovery: if every entry in a chunk reports dead-port, we
+// invalidate the cached engine promise and retry the chunk ONCE. This handles
+// the common case where the user toggled engine prefs and the ML engine's
+// port closed — recreating loads a fresh engine. Limited to one retry per
+// batch to avoid infinite recreation loops when the engine genuinely won't
+// load.
+const embedBatch = async (inputs, opts = {}) => {
+  const batchSize = opts.batchSize ?? CONFIG.AI_EMBEDDING_BATCH_SIZE;
+  const yieldBetween = !!opts.yieldBetween;
   const out = [];
-  for (let i = 0; i < inputs.length; i += CONFIG.AI_EMBEDDING_BATCH_SIZE) {
-    const chunk = inputs.slice(i, i + CONFIG.AI_EMBEDDING_BATCH_SIZE);
-    const results = await Promise.all(chunk.map(embed));
-    out.push(...results);
+  let alreadyRecreated = false;
+  for (let i = 0; i < inputs.length; i += batchSize) {
+    const chunk = inputs.slice(i, i + batchSize);
+    let results = await Promise.all(chunk.map(embed));
+    // A genuinely dead engine yields SENTINEL for every input it touches. Inputs that buildEmbedText
+    // rejected as empty come back as plain null. Treat the chunk as "dead-port suspected" when at
+    // least one says SENTINEL and nothing succeeded.
+    const someDead = results.some((r) => r === DEAD_PORT_SENTINEL);
+    const allDeadOrNull = results.every((r) => r === DEAD_PORT_SENTINEL || r === null);
+    if (someDead && allDeadOrNull && !alreadyRecreated) {
+      console.warn(`${LOG} embedBatch: every embed reported "Port does not exist" — invalidating engine cache and retrying chunk`);
+      embeddingEnginePromise = null;
+      alreadyRecreated = true;
+      results = await Promise.all(chunk.map(embed));
+    }
+    // Normalize sentinels back to null so downstream code sees a clean
+    // "couldn't embed this one" signal.
+    for (const r of results) out.push(r === DEAD_PORT_SENTINEL ? null : r);
+    if (yieldBetween && i + batchSize < inputs.length) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
   }
   return out;
 };
@@ -164,7 +216,10 @@ const embedBatch = async (inputs) => {
 // rule-defined identity. Without this, a tab that AI moved into a group last run
 // with the "transient" behavior — but isn't claimed by the rule — would show up
 // here AND as an unmatched candidate this run, causing a self-match (cosine 1.0).
-const computeExistingGroupTabEmbeddings = async (workspaceId, rules, excludeTabs = new Set()) => {
+const computeExistingGroupTabEmbeddings = async (workspaceId, rules, excludeTabs = new Set(), opts = {}) => {
+  // Forward chunking opts so large-workspace callers can pass batchSize +
+  // yieldBetween through to embedBatch and avoid a long blocking embed pass.
+  const { batchSize, yieldBetween } = opts;
   const ruleNames = new Set(rules.map((r) => r.name));
   const groupEmbeddings = new Map(); // groupName → number[][]
   const groups = document.querySelectorAll(
@@ -187,7 +242,7 @@ const computeExistingGroupTabEmbeddings = async (workspaceId, rules, excludeTabs
       })(),
     })).filter((i) => i.title);
     if (inputs.length === 0) continue;
-    const embs = (await embedBatch(inputs)).filter((v) => v);
+    const embs = (await embedBatch(inputs, { batchSize, yieldBetween })).filter((v) => v);
     if (embs.length === 0) continue;
     groupEmbeddings.set(label, embs);
   }
@@ -213,12 +268,50 @@ export const runPass2 = async (unmatched, rules, workspaceId) => {
   const empty = { assignedToExisting: [], newGroups: [], skipped: [] };
   if (!unmatched || unmatched.length === 0) return empty;
 
-  // 1. Embed every unmatched tab using title + hostname as the input text.
-  let tabEmbeddings;
+  // Chunking decision. On large workspaces (>CHUNK_THRESHOLD unmatched tabs)
+  // we switch to a more conservative path:
+  //   - Hostname dedupe: embed one representative tab per unique hostname;
+  //     reuse the embedding for all siblings (50 amazon.com tabs → 1 embed).
+  //   - Yield between batches: avoid freezing the browser.
+  // Below the threshold we use the original 1-embed-per-tab flow with the
+  // small AI_EMBEDDING_BATCH_SIZE — there's no point chunking when there's
+  // little work to do.
+  const useChunking = unmatched.length > CONFIG.AI_LOCAL_CHUNK_THRESHOLD;
+  const batchSize = useChunking ? getLocalAIBatchSize() : CONFIG.AI_EMBEDDING_BATCH_SIZE;
+
+  // Resolve a per-tab embedding. Without chunking, `tabEmbeddings[i]`.
+  // With chunking, the embedding for the tab's hostname (one per hostname).
+  let getEmbeddingForTab;
+
   try {
-    tabEmbeddings = await embedBatch(
-      unmatched.map((t) => ({ title: t.title, hostname: t.hostname }))
-    );
+    if (useChunking) {
+      // Dedupe by hostname: pick the first tab encountered per hostname as
+      // the representative. Group siblings get the same embedding/result.
+      // Guard truthy hostname so hostless tabs (about:*, chrome://, file://)
+      // don't all collapse onto one rep — they fall through to the skipped path.
+      const repByHostname = new Map();
+      for (const t of unmatched) {
+        if (t.hostname && !repByHostname.has(t.hostname)) repByHostname.set(t.hostname, t);
+      }
+      const reps = [...repByHostname.values()];
+      console.log(`${LOG} AI: large workspace (${unmatched.length} > ${CONFIG.AI_LOCAL_CHUNK_THRESHOLD}) — chunking on, deduped to ${reps.length} unique hostname(s), batchSize=${batchSize}`);
+
+      const repEmbeddings = await embedBatch(
+        reps.map((t) => ({ title: t.title, hostname: t.hostname })),
+        { batchSize, yieldBetween: true },
+      );
+      const hostToEmb = new Map();
+      reps.forEach((t, i) => {
+        if (repEmbeddings[i]) hostToEmb.set(t.hostname, repEmbeddings[i]);
+      });
+      getEmbeddingForTab = (tabInfo) => hostToEmb.get(tabInfo.hostname);
+    } else {
+      const tabEmbeddings = await embedBatch(
+        unmatched.map((t) => ({ title: t.title, hostname: t.hostname })),
+        { batchSize },
+      );
+      getEmbeddingForTab = (_tabInfo, idx) => tabEmbeddings[idx];
+    }
   } catch (e) {
     console.error(`${LOG} AI: failed to load embedding engine:`, e);
     showToast("AI sorting unavailable — embedding model failed to load");
@@ -230,7 +323,10 @@ export const runPass2 = async (unmatched, rules, workspaceId) => {
   //    run (with the "transient" behavior, so no rule update) would self-match
   //    against itself at cosine 1.0 this run.
   const excludeSet = new Set(unmatched.map((t) => t._tab).filter((t) => t));
-  const groupTabEmbeddings = await computeExistingGroupTabEmbeddings(workspaceId, rules, excludeSet);
+  const groupTabEmbeddings = await computeExistingGroupTabEmbeddings(workspaceId, rules, excludeSet, {
+    batchSize: useChunking ? batchSize : undefined,
+    yieldBetween: useChunking,
+  });
   console.log(`${LOG} AI: collected per-tab embeddings for ${groupTabEmbeddings.size} existing group(s): ${[...groupTabEmbeddings.keys()].map((n) => `${n}(${groupTabEmbeddings.get(n).length})`).join(", ") || "(none)"}`);
 
   // 3. Try to slot each unmatched tab into an existing group using MAX similarity
@@ -239,7 +335,7 @@ export const runPass2 = async (unmatched, rules, workspaceId) => {
   const remainder = []; // { info, embedding } for tabs that didn't fit
   for (let i = 0; i < unmatched.length; i++) {
     const tabInfo = unmatched[i];
-    const emb = tabEmbeddings[i];
+    const emb = getEmbeddingForTab(tabInfo, i);
     if (!emb) { empty.skipped.push(tabInfo); continue; }
 
     let best = null;
@@ -262,7 +358,10 @@ export const runPass2 = async (unmatched, rules, workspaceId) => {
       const verdict = best
         ? `picked ${best.groupName} (${best.sim.toFixed(3)})`
         : `no match (threshold ${CONFIG.AI_EXISTING_GROUP_THRESHOLD})`;
-      console.log(`${LOG} AI sim for "${tabInfo.hostname || tabInfo.title}": ${allSims.join(", ")} → ${verdict}`);
+      // Per-tab firing in the unmatched loop — debug so it only surfaces when
+      // Verbose log level is enabled; still genuinely useful for diagnosing
+      // threshold/embedding issues.
+      console.debug(`${LOG} AI sim for "${tabInfo.hostname || tabInfo.title}": ${allSims.join(", ")} → ${verdict}`);
     }
     if (best) {
       assignedToExisting.push({ tabInfo, groupName: best.groupName, similarity: best.sim });
@@ -272,17 +371,404 @@ export const runPass2 = async (unmatched, rules, workspaceId) => {
   }
 
   // Local AI is intentionally limited to assigning into EXISTING groups only.
-  // New-cluster formation (and the smart-tab-topic naming model) produced unreliable
-  // results — the embedding model clusters by stylistic similarity (homepage-style
-  // titles) rather than topic, and the score range is too compressed to threshold
-  // safely. New-group classification is delegated to the Ollama-backed path
-  // in modules/ollama.mjs.
+  // New-cluster formation is opt-in via `runPass2Fresh` below — see its comment
+  // for the trade-offs (no LLM means no abstract names, and smart-tab-embedding
+  // clusters by stylistic title similarity rather than topic).
 
   return {
     assignedToExisting,
     newGroups: [],
     skipped: [...empty.skipped, ...remainder.map((r) => r.info)],
   };
+};
+
+// ─── Local Fresh: cluster-from-scratch into new groups ────────────────────────
+//
+// No LLM, so no abstract naming — clusters are named from member hostnames:
+//   - 1 unique brand        → "Github"
+//   - 2 unique brands       → "Github & Gitlab"
+//   - 3 unique brands       → "Github, Gitlab & Bitbucket"
+//   - 4+                    → "Github + 3 more"
+//
+// Use Plan Mode (identify-only) so the user can rename clusters before applying.
+// Caveat: Mozilla's smart-tab-embedding model clusters by stylistic title
+// similarity (homepage-style pages cluster together regardless of topic), so
+// results are quirky vs. Ollama. The user gets the option; the modal is the
+// safety net.
+
+const FRESH_CLUSTER_THRESHOLD = 0.55; // raw cosine — broader than existing-group matching
+const FRESH_MERGE_THRESHOLD = 0.40;   // 3rd-pass centroid-merge — looser than initial pairing
+const FRESH_MIN_CLUSTER_SIZE = 2;     // singletons demoted to skipped
+
+const etld1 = (hostname) => {
+  if (!hostname) return "";
+  const parts = hostname.split(".");
+  if (parts.length < 2) return hostname;
+  return parts.slice(-2).join(".");
+};
+
+const titleCase = (s) =>
+  s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+
+const nameClusterFromHostnames = (tabs) => {
+  const counts = new Map();
+  for (const t of tabs) {
+    const e = etld1(t.hostname);
+    if (!e) continue;
+    counts.set(e, (counts.get(e) || 0) + 1);
+  }
+  if (counts.size === 0) return "Cluster";
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const baseOf = (e) => titleCase(e.split(".")[0]);
+  if (counts.size === 1) return baseOf(sorted[0][0]);
+  if (counts.size === 2) return `${baseOf(sorted[0][0])} & ${baseOf(sorted[1][0])}`;
+  if (counts.size === 3) return `${baseOf(sorted[0][0])}, ${baseOf(sorted[1][0])} & ${baseOf(sorted[2][0])}`;
+  return `${baseOf(sorted[0][0])} + ${counts.size - 1} more`;
+};
+
+// Map an Open Graph `type` value to an Arc-tidy-style intent label. These
+// describe the NATURE of the page (what the user is doing with it) rather
+// than the brand. og:type is the most reliable signal we have without an
+// LLM — and modern sites populate it widely.
+const INTENT_BY_OG_TYPE = {
+  article: "Reading",
+  blog: "Reading",
+  book: "Reading",
+  website: null,           // too generic — fall through to hostname naming
+  video: "Watching",
+  "video.movie": "Watching",
+  "video.episode": "Watching",
+  "video.tv_show": "Watching",
+  "video.other": "Watching",
+  music: "Listening",
+  "music.song": "Listening",
+  "music.album": "Listening",
+  "music.playlist": "Listening",
+  "music.radio_station": "Listening",
+  product: "Shopping",
+  "product.group": "Shopping",
+  "product.item": "Shopping",
+  profile: "Social",
+  place: "Places",
+  event: "Events",
+};
+
+const intentFromOgType = (type) => {
+  if (!type) return null;
+  const lower = type.toLowerCase().trim();
+  if (INTENT_BY_OG_TYPE[lower] !== undefined) return INTENT_BY_OG_TYPE[lower];
+  // Prefix match — covers nonstandard subtypes like "video.foo".
+  for (const [k, v] of Object.entries(INTENT_BY_OG_TYPE)) {
+    if (lower.startsWith(k + ".")) return v;
+  }
+  return null;
+};
+
+const parseOgTypeFromSnippet = (snippet) => {
+  if (!snippet) return null;
+  const m = snippet.match(/\[type:\s*([^\]]+)\]/i);
+  return m ? m[1].trim().toLowerCase() : null;
+};
+
+// English stopwords + page-chrome boilerplate that frequently appears in tab
+// titles but says nothing about the cluster's topic. Intentionally
+// conservative — too aggressive a list filters real signal too.
+const STOPWORDS = new Set([
+  // articles, pronouns, common verbs
+  "the","a","an","and","or","but","of","to","in","on","at","for","with","by","from","as",
+  "is","are","was","were","be","been","being","have","has","had","do","does","did","will",
+  "would","could","should","may","might","can","this","that","these","those","you","your",
+  "we","our","i","my","me","it","its","they","their","them","he","she","his","her","not",
+  // page chrome
+  "page","home","site","website","official","login","sign","search","menu","welcome",
+  "404","error","found","settings","preferences","dashboard","profile","account",
+  // ranking adjectives that appear in too many headlines to mean anything
+  "best","top","latest","new","more","less","free","all","most","least","good","great",
+]);
+
+const tokenizeForKeywords = (text) =>
+  text.toLowerCase()
+    .replace(/&[a-z]+;|&#\d+;/gi, " ")     // strip HTML entities
+    .replace(/[^\w\s'-]/g, " ")            // keep hyphens + apostrophes inside words
+    .split(/\s+/)
+    .filter((w) => w.length >= 3 && !STOPWORDS.has(w) && !/^\d+$/.test(w));
+
+// Pull a [topic: ...] phrase from a snippet, if present.
+const parseTopicFromSnippet = (snippet) => {
+  if (!snippet) return "";
+  const m = snippet.match(/\[topic:\s*([^\]]+)\]/i);
+  return m ? m[1].trim() : "";
+};
+
+// Find words that recur across multiple distinct hostnames in the cluster.
+// Counting by HOSTNAME (not raw token frequency) prevents a chatty
+// single-site cluster from inflating its own brand into the cluster label.
+const extractClusterKeywords = (tabs, snippetByHostname) => {
+  const tokensByHostname = new Map();
+  for (const t of tabs) {
+    // Skip hostless tabs so they don't bucket under the empty-string fake host
+    // and inflate uniqueHosts (which would skew the minShare threshold).
+    const hostname = t.hostname;
+    if (!hostname) continue;
+    const topic = parseTopicFromSnippet(snippetByHostname.get(hostname));
+    const text = `${t.title || ""} ${topic}`;
+    const tokens = new Set(tokenizeForKeywords(text));
+    // Don't let a token win just because the brand IS the word (yugipedia
+    // tabs containing "yugipedia") — strip hostname-derived tokens so the
+    // shared content words dominate.
+    const hostBaseTokens = tokenizeForKeywords(hostname.replace(/\./g, " "));
+    for (const ht of hostBaseTokens) tokens.delete(ht);
+    if (!tokensByHostname.has(hostname)) tokensByHostname.set(hostname, new Set());
+    const acc = tokensByHostname.get(hostname);
+    for (const tok of tokens) acc.add(tok);
+  }
+  const wordToHosts = new Map();
+  for (const [hostname, tokens] of tokensByHostname) {
+    for (const tok of tokens) {
+      if (!wordToHosts.has(tok)) wordToHosts.set(tok, new Set());
+      wordToHosts.get(tok).add(hostname);
+    }
+  }
+  const uniqueHosts = tokensByHostname.size;
+  // Require the word to appear in at least min(half-the-hosts, 2) so it's a
+  // shared signal, not single-site noise.
+  const minShare = Math.max(2, Math.ceil(uniqueHosts / 2));
+  return [...wordToHosts.entries()]
+    .filter(([, hosts]) => hosts.size >= minShare)
+    .sort((a, b) => b[1].size - a[1].size)
+    .slice(0, 2)
+    .map(([word]) => word);
+};
+
+// Light Title-Case for arbitrary tokens that may already contain hyphens
+// (e.g. "yu-gi-oh" → "Yu-Gi-Oh") or apostrophes ("don't" → "Don't").
+const titleCaseToken = (s) =>
+  s.split(/(\s|-|')/).map((p) => p ? p[0].toUpperCase() + p.slice(1).toLowerCase() : p).join("");
+
+// Pick a cluster name from page signals. Priority:
+//   1. shared keyword(s) + intent label   → "Yu-Gi-Oh Reading"
+//   2. shared keyword(s) alone            → "Yu-Gi-Oh"
+//   3. intent label alone                 → "Reading"
+//   4. hostname stitch                    → "Github & Gitlab"
+const nameClusterFromSignals = (tabs, snippetByHostname) => {
+  // 1+3 — intent label from og:type majority
+  const intentCounts = new Map();
+  for (const t of tabs) {
+    const snip = snippetByHostname.get(t.hostname);
+    const ogType = parseOgTypeFromSnippet(snip);
+    const intent = intentFromOgType(ogType);
+    if (intent) intentCounts.set(intent, (intentCounts.get(intent) || 0) + 1);
+  }
+  let intentName = null;
+  if (intentCounts.size > 0) {
+    const sorted = [...intentCounts.entries()].sort((a, b) => b[1] - a[1]);
+    const [topIntent, topCount] = sorted[0];
+    if (topCount >= Math.ceil(tabs.length / 2)) intentName = topIntent;
+  }
+  // 1+2 — keyword extraction from titles + [topic:] across distinct hostnames
+  const keywords = extractClusterKeywords(tabs, snippetByHostname);
+  if (keywords.length > 0 && intentName) {
+    return `${titleCaseToken(keywords[0])} ${intentName}`;
+  }
+  if (keywords.length > 0) {
+    return keywords.map(titleCaseToken).join(" ");
+  }
+  if (intentName) return intentName;
+  // 4 — hostname stitch fallback
+  return nameClusterFromHostnames(tabs);
+};
+
+/**
+ * Cluster eligible tabs into NEW groups using embedding similarity alone.
+ * Returns the same shape as `runPass2Ollama`/`runPass2OllamaFresh` so the
+ * caller can treat them uniformly.
+ *
+ * @param {Array} tabs — all eligible tab info objects (Pass 2 fresh-like input)
+ */
+export const runPass2Fresh = async (tabs) => {
+  const empty = { assignedToExisting: [], newGroups: [], skipped: [] };
+  if (!tabs || tabs.length === 0) return empty;
+
+  // Hostname-dedupe + chunked embed (same infra as runPass2's chunked path).
+  const repByHostname = new Map();
+  for (const t of tabs) {
+    if (t.hostname && !repByHostname.has(t.hostname)) repByHostname.set(t.hostname, t);
+  }
+  const reps = [...repByHostname.values()];
+  const useChunking = tabs.length > CONFIG.AI_LOCAL_CHUNK_THRESHOLD;
+  const batchSize = useChunking ? getLocalAIBatchSize() : CONFIG.AI_EMBEDDING_BATCH_SIZE;
+  console.log(
+    `${LOG} Local Fresh: ${tabs.length} tab(s) → ${reps.length} unique hostname(s), batchSize=${batchSize}, chunking=${useChunking}`
+  );
+
+  // Fetch page snippets for each unique hostname so the embedding model has
+  // real page context — og:type, og:site_name, h1, description — not just the
+  // bare title. This is the same enriched signal block we feed to Ollama, and
+  // it produces noticeably better clusters on Local since the embedder gets
+  // semantic content beyond just the homepage-style title pattern.
+  // Bounded parallel: fetchPageSnippet has its own 3s timeout per request; we
+  // fire them all in parallel and let the slow ones drop to "" silently.
+  const snippetT0 = performance.now();
+  const snippets = await Promise.all(reps.map((t) => {
+    const url = t.url || "";
+    // Only fetch the tab's actual http(s) URL. Non-http(s) tabs (about:*, chrome://, file://,
+    // javascript:, data:, blob:) have no real-world snippet — falling back to a synthetic
+    // https://hostname/ URL would fetch the wrong page (someone else's homepage).
+    if (!url.startsWith("http://") && !url.startsWith("https://")) return "";
+    return fetchPageSnippet(url);
+  }));
+  const hitCount = snippets.filter((s) => s).length;
+  console.log(
+    `${LOG} Local Fresh: fetched page snippets for ${hitCount}/${reps.length} tab(s) in ${Math.round(performance.now() - snippetT0)}ms`
+  );
+  // Index by hostname so nameClusterFromSignals can look up og:type when
+  // picking an intent-style name later.
+  const snippetByHostname = new Map();
+  reps.forEach((t, i) => {
+    if (snippets[i]) snippetByHostname.set(t.hostname, snippets[i]);
+  });
+
+  let hostToEmb;
+  try {
+    // Build a richer text input per representative: title + (hostname) +
+    // snippet. The embed function accepts strings directly (bypassing the
+    // default {title, hostname} → "title (hostname)" formatter).
+    const repInputs = reps.map((t, i) => {
+      const parts = [];
+      if (t.title) parts.push(t.title);
+      if (t.hostname) parts.push(`(${t.hostname})`);
+      if (snippets[i]) parts.push(snippets[i]);
+      return parts.join(" ").trim() || t.hostname || t.title || "";
+    });
+    const repEmbeddings = await embedBatch(repInputs, { batchSize, yieldBetween: useChunking });
+    hostToEmb = new Map();
+    reps.forEach((t, i) => {
+      if (repEmbeddings[i]) hostToEmb.set(t.hostname, repEmbeddings[i]);
+    });
+  } catch (e) {
+    console.error(`${LOG} Local Fresh: embedding engine failed:`, e);
+    showToast("Local clustering unavailable — embedding model failed to load");
+    return { ...empty, skipped: tabs, failed: "embedding engine load failed" };
+  }
+
+  // Union-find over UNIQUE hostnames (same hostname always clusters together
+  // since they share an embedding — no point comparing per-tab).
+  const hostnames = [...hostToEmb.keys()];
+  const parent = Array.from({ length: hostnames.length }, (_, i) => i);
+  const find = (i) => (parent[i] === i ? i : (parent[i] = find(parent[i])));
+  const union = (i, j) => { parent[find(i)] = find(j); };
+
+  for (let i = 0; i < hostnames.length; i++) {
+    const a = hostToEmb.get(hostnames[i]);
+    for (let j = i + 1; j < hostnames.length; j++) {
+      const b = hostToEmb.get(hostnames[j]);
+      if (cosineSimilarity(a, b) >= FRESH_CLUSTER_THRESHOLD) union(i, j);
+    }
+  }
+
+  const hostnameToCluster = new Map();
+  for (let i = 0; i < hostnames.length; i++) {
+    hostnameToCluster.set(hostnames[i], find(i));
+  }
+
+  // ── 3rd pass: centroid-similarity merge ─────────────────────────────────────
+  // After the tight per-pair clustering, over-fragmented clusters often have
+  // very similar centroids that didn't quite cross the tight threshold (e.g.
+  // multiple TCG sites split into 3 clusters because no single pair hit 0.55).
+  // We compute a centroid per cluster and merge cluster pairs whose centroids
+  // hit a looser threshold. This is hierarchical-clustering-lite without the
+  // bookkeeping cost of true single-linkage on every iteration.
+  const groupHostnamesByCluster = new Map(); // clusterId → [hostname, ...]
+  for (let i = 0; i < hostnames.length; i++) {
+    const cid = find(i);
+    if (!groupHostnamesByCluster.has(cid)) groupHostnamesByCluster.set(cid, []);
+    groupHostnamesByCluster.get(cid).push(hostnames[i]);
+  }
+  const centroids = new Map();
+  for (const [cid, hosts] of groupHostnamesByCluster) {
+    const embs = hosts.map((h) => hostToEmb.get(h)).filter(Boolean);
+    if (embs.length === 0) continue;
+    const avg = averageVectors(embs);
+    if (avg) centroids.set(cid, l2Normalize(avg));
+  }
+  const mergeCids = [...centroids.keys()];
+  const mergeParent = new Map(mergeCids.map((c) => [c, c]));
+  const findM = (c) => {
+    let r = c;
+    while (mergeParent.get(r) !== r) r = mergeParent.get(r);
+    let cur = c;
+    while (mergeParent.get(cur) !== r) {
+      const next = mergeParent.get(cur);
+      mergeParent.set(cur, r);
+      cur = next;
+    }
+    return r;
+  };
+  let mergedPairs = 0;
+  for (let i = 0; i < mergeCids.length; i++) {
+    const a = centroids.get(mergeCids[i]);
+    for (let j = i + 1; j < mergeCids.length; j++) {
+      const b = centroids.get(mergeCids[j]);
+      const sim = cosineSimilarity(a, b);
+      if (sim >= FRESH_MERGE_THRESHOLD && findM(mergeCids[i]) !== findM(mergeCids[j])) {
+        mergeParent.set(findM(mergeCids[i]), findM(mergeCids[j]));
+        mergedPairs++;
+      }
+    }
+  }
+  if (mergedPairs > 0) {
+    console.log(`${LOG} Local Fresh: merge pass linked ${mergedPairs} cluster pair(s) at centroid-sim ≥ ${FRESH_MERGE_THRESHOLD}`);
+    // Re-apply merge to hostname→cluster mapping
+    for (const h of hostnameToCluster.keys()) {
+      const oldCid = hostnameToCluster.get(h);
+      hostnameToCluster.set(h, findM(oldCid));
+    }
+  }
+
+  // Bucket every input tab into its cluster (or skip if its hostname had no
+  // embedding — e.g. about:* tabs).
+  const clusters = new Map();
+  const skipped = [];
+  for (const t of tabs) {
+    const cid = hostnameToCluster.get(t.hostname);
+    if (cid === undefined) { skipped.push(t); continue; }
+    if (!clusters.has(cid)) clusters.set(cid, []);
+    clusters.get(cid).push(t);
+  }
+
+  // Demote singletons to skipped; everything else becomes a new group.
+  const rawGroups = [];
+  for (const members of clusters.values()) {
+    if (members.length < FRESH_MIN_CLUSTER_SIZE) {
+      skipped.push(...members);
+    } else {
+      rawGroups.push({ name: nameClusterFromSignals(members, snippetByHostname), tabs: members });
+    }
+  }
+
+  // ── Name-dedupe: if the hostname-naming heuristic produced collisions
+  // (e.g. two separate Google-flavored clusters both named "Google"), merge
+  // them into one. Final safety net beyond the centroid pass.
+  const byName = new Map();
+  const newGroups = [];
+  let nameDedupes = 0;
+  for (const g of rawGroups) {
+    if (byName.has(g.name)) {
+      byName.get(g.name).tabs.push(...g.tabs);
+      nameDedupes++;
+    } else {
+      byName.set(g.name, g);
+      newGroups.push(g);
+    }
+  }
+  if (nameDedupes > 0) {
+    console.log(`${LOG} Local Fresh: deduped ${nameDedupes} duplicate-named cluster(s)`);
+  }
+
+  console.log(
+    `${LOG} Local Fresh: ${newGroups.length} cluster(s), ${skipped.length} singleton(s)/no-host tab(s) skipped`
+  );
+  return { assignedToExisting: [], newGroups, skipped };
 };
 
 // ─── Apply the AI decisions ───────────────────────────────────────────────────

--- a/modules/browser-hooks.mjs
+++ b/modules/browser-hooks.mjs
@@ -22,8 +22,8 @@
 
 import { CONFIG, LOG, BUILD_VERSION, isZenColorName, isUnsetLabel } from "./config.mjs";
 import { getTabUrl, getHostname } from "./tabs.mjs";
-import { readRulesPref, writeRulesPref, readSkipDomainsPref, writeSkipDomainsPref, isMinimalStyle } from "./rules.mjs";
-import { applyGroupColor, syncAllGroupColors } from "./groups.mjs";
+import { readRulesPref, writeRulesPref, readSkipDomainsPref, writeSkipDomainsPref, readCollapsedGroupsPref, writeCollapsedGroupsPref, isMinimalStyle } from "./rules.mjs";
+import { applyGroupColor, syncAllGroupColors, moveTabsToTop } from "./groups.mjs";
 
 // ─── Helpers (module level so they're reusable + easy to find) ───────────────
 
@@ -33,7 +33,9 @@ const applyToRule = (tab, groupName, group) => {
   const hostname = getHostname(getTabUrl(tab));
   if (!hostname) return;
 
-  const rules = readRulesPref() || [];
+  // keepIncomplete: true so we can find an existing in-progress rule by
+  // name and grow it, rather than creating a duplicate with the same name.
+  const rules = readRulesPref({ keepIncomplete: true }) || [];
   const rule = rules.find((r) => r.name === groupName);
 
   if (rule) {
@@ -119,7 +121,13 @@ export const setupTabContextMenu = () => {
 
   const onSubmenuShowing = () => {
     while (popup.firstChild) popup.firstChild.remove();
-    const rules = readRulesPref() || [];
+    // keepIncomplete: true so a named-but-domainless in-progress rule
+    // shows up here — clicking it adds the current tab's hostname as its
+    // first domain (which is exactly the natural way to populate a fresh
+    // rule). A blank-name placeholder row (still untitled in the editor)
+    // is suppressed below so we don't surface an empty menu entry.
+    const allRules = readRulesPref({ keepIncomplete: true }) || [];
+    const rules = allRules.filter((r) => r.name && r.name.length > 0);
     const skipList = readSkipDomainsPref() || [];
     if (rules.length === 0) {
       const placeholder = document.createXULElement("menuitem");
@@ -191,37 +199,254 @@ export const teardownTabContextMenu = () => {
   menu._zaoContextMenuInstalled = null;
 };
 
+// ─── Tab-group right-click: "Dissolve group" ─────────────────────────────────
+//
+// Zen routes right-clicks on tab-group labels to Firefox's standard toolbar
+// context menu (#toolbar-context-menu) — the same menu used for empty
+// sidebar / toolbar customization. We append a "Dissolve group" entry that's
+// only visible when the right-click happened on a tab-group label.
+//
+// "Dissolve group" — ungroup all tabs in the group AND move them to the top
+// of the workspace. The matching rule in settings stays intact so the next
+// wand click would re-create the group from whatever tabs match the rule.
+
+const TOOLBAR_CONTEXT_MENU_ID = "toolbar-context-menu";
+
+// Most recent tab-group that was right-clicked. Set by our capture-phase
+// contextmenu listener; read by the menu's popupshowing handler to decide
+// whether to show the "Dissolve group" item.
+let _pendingDissolveTargetGroup = null;
+
+const dissolveTabGroup = (group) => {
+  if (!group?.isConnected) return;
+  const workspaceId = window.gZenWorkspaces?.activeWorkspace;
+  if (!workspaceId) {
+    console.warn(`${LOG} dissolveTabGroup: no active workspace`);
+    return;
+  }
+  const tabs = Array.from(group.querySelectorAll(`tab[zen-workspace-id="${workspaceId}"]`))
+    .filter((t) => t.isConnected);
+  if (tabs.length === 0) {
+    // Empty group — just remove the element.
+    try { group.remove(); } catch {}
+    return;
+  }
+  const groupName = group.getAttribute?.("label") || "(unnamed)";
+  // moveTabsToTop handles gBrowser.ungroupTab + DOM reparent to top, the same
+  // path strict-mode ejection and skip-domain parking use.
+  const moved = moveTabsToTop(tabs, workspaceId);
+  console.log(`${LOG} dissolved group "${groupName}" — ejected ${moved} tab(s) to top of workspace`);
+  // Group element typically auto-removes when empty, but defensively remove
+  // it ourselves if it lingered.
+  setTimeout(() => {
+    if (group.isConnected && !group.querySelector("tab")) {
+      try { group.remove(); } catch {}
+    }
+  }, 50);
+};
+
+// Capture-phase contextmenu listener — fires BEFORE the toolbar context menu
+// opens so the pending-target is set in time for popupshowing.
+const onContextMenuCapture = (e) => {
+  _pendingDissolveTargetGroup = e.target?.closest?.("tab-group") || null;
+};
+
+let _onMenuShowing = null;
+let _onMenuHidden = null;
+let _onMenuItemCommand = null;
+
+export const setupTabGroupContextMenu = () => {
+  const menu = document.getElementById(TOOLBAR_CONTEXT_MENU_ID);
+  if (!menu) {
+    console.warn(`${LOG} #${TOOLBAR_CONTEXT_MENU_ID} not found — Dissolve group menuitem not installed`);
+    return;
+  }
+  if (menu._zaoDissolveInstalled) return;
+  menu._zaoDissolveInstalled = true;
+
+  // Build menuitem + separator. Hidden by default; shown on popupshowing when
+  // the most recent right-click was on a tab-group.
+  const separator = document.createXULElement("menuseparator");
+  separator.id = "zen-tab-wand-dissolve-separator";
+  separator.setAttribute("hidden", "true");
+
+  const item = document.createXULElement("menuitem");
+  item.id = "zen-tab-wand-dissolve-group";
+  item.setAttribute("label", "Dissolve group");
+  item.setAttribute("hidden", "true");
+
+  // Insert at the top of the menu so it's prominent when shown. (The native
+  // Zen items remain in their normal positions below.)
+  menu.prepend(separator);
+  menu.prepend(item);
+
+  _onMenuShowing = () => {
+    const group = _pendingDissolveTargetGroup;
+    const show = !!group;
+    item.hidden = !show;
+    separator.hidden = !show;
+    if (show) {
+      const name = group.getAttribute?.("label") || "(unnamed)";
+      item.setAttribute("label", `Dissolve group "${name}"`);
+    }
+  };
+  _onMenuHidden = () => {
+    // Clear after the menu closes (whether from click or dismiss) so a
+    // subsequent non-group right-click doesn't surface our item stale.
+    _pendingDissolveTargetGroup = null;
+  };
+  _onMenuItemCommand = () => {
+    const group = _pendingDissolveTargetGroup;
+    if (!group) {
+      console.warn(`${LOG} dissolve clicked but no target group captured`);
+      return;
+    }
+    dissolveTabGroup(group);
+  };
+
+  menu.addEventListener("popupshowing", _onMenuShowing);
+  menu.addEventListener("popuphidden", _onMenuHidden);
+  item.addEventListener("command", _onMenuItemCommand);
+  document.addEventListener("contextmenu", onContextMenuCapture, true);
+
+  console.log(`${LOG} #${TOOLBAR_CONTEXT_MENU_ID}: 'Dissolve group' menuitem installed`);
+};
+
+export const teardownTabGroupContextMenu = () => {
+  const menu = document.getElementById(TOOLBAR_CONTEXT_MENU_ID);
+  if (menu) {
+    if (_onMenuShowing) menu.removeEventListener("popupshowing", _onMenuShowing);
+    if (_onMenuHidden) menu.removeEventListener("popuphidden", _onMenuHidden);
+    menu._zaoDissolveInstalled = false;
+    const item = menu.querySelector?.("#zen-tab-wand-dissolve-group");
+    const sep = menu.querySelector?.("#zen-tab-wand-dissolve-separator");
+    if (item?.isConnected) try { item.remove(); } catch {}
+    if (sep?.isConnected) try { sep.remove(); } catch {}
+  }
+  document.removeEventListener("contextmenu", onContextMenuCapture, true);
+  _onMenuShowing = null;
+  _onMenuHidden = null;
+  _onMenuItemCommand = null;
+  _pendingDissolveTargetGroup = null;
+};
+
 // On every tab-group creation (including session restore on startup), re-apply the
 // rule's color so it survives across browser restarts even if Zen's session storage
 // dropped our previously-set color.
+// Apply our saved state to a tab-group: re-collapse if its label is in the
+// collapsed-set pref, and re-apply its rule color. Used both as the
+// TabGroupCreate event handler (for newly-created groups) and at install
+// time (for groups Zen restored before our script loaded).
+const applyTabGroupRestoreState = (group) => {
+  try {
+    if (!group?.isConnected) return;
+    const label = group.getAttribute?.("label");
+    if (!label) return;
+
+    // Restore collapsed state. Deferred so Zen's own group setup finishes
+    // before we toggle. Use the property setter, not setAttribute, so
+    // Firefox also updates aria-hidden on inner tabs (which the collapse
+    // CSS rule relies on).
+    const collapsedSet = readCollapsedGroupsPref();
+    if (collapsedSet.has(label)) {
+      setTimeout(() => {
+        if (!group.isConnected) return;
+        let applied = false;
+        try { group.collapsed = true; applied = true; } catch {}
+        if (!applied) {
+          try { group.setAttribute("collapsed", ""); } catch {}
+          // Property setter wasn't available — manually mark aria-hidden on
+          // non-selected tabs so our CSS rule actually hides them.
+          for (const tab of group.querySelectorAll("tab")) {
+            if (!tab.hasAttribute("selected")) {
+              try { tab.setAttribute("aria-hidden", "true"); } catch {}
+            }
+          }
+        }
+      }, 0);
+    }
+
+    const rules = readRulesPref() || [];
+    const rule = rules.find((r) => r.name === label);
+    if (rule?.color) {
+      // Defer one tick so Zen's own color setup (which runs synchronously
+      // during group construction) is done before we override.
+      setTimeout(() => {
+        if (group.isConnected) applyGroupColor(group, rule.color);
+      }, 0);
+    }
+  } catch (e) {
+    console.error(`${LOG} applyTabGroupRestoreState error:`, e);
+  }
+};
+
 export const setupTabGroupCreateHook = () => {
   if (typeof gBrowser === "undefined" || !gBrowser.tabContainer) return;
   if (gBrowser.tabContainer._zaoTabGroupCreateHook) return;
 
-  const handler = (event) => {
-    try {
-      const group = event.target;
-      if (!group?.isConnected) return;
-      const label = group.getAttribute?.("label");
-      if (!label) return;
-
-      const rules = readRulesPref() || [];
-      const rule = rules.find((r) => r.name === label);
-      if (!rule?.color) return;
-
-      // Defer one tick so Zen's own color setup (which runs synchronously during
-      // group construction) is done before we override.
-      setTimeout(() => {
-        if (group.isConnected) applyGroupColor(group, rule.color);
-      }, 0);
-    } catch (e) {
-      console.error(`${LOG} TabGroupCreate handler error:`, e);
-    }
-  };
-
+  const handler = (event) => applyTabGroupRestoreState(event.target);
   gBrowser.tabContainer.addEventListener("TabGroupCreate", handler);
   gBrowser.tabContainer._zaoTabGroupCreateHook = handler;
+
+  // Already-existing tab-groups — session restore likely fired
+  // TabGroupCreate BEFORE we installed the listener. Process them now.
+  const existing = document.querySelectorAll("tab-group");
+  if (existing.length > 0) {
+    console.log(`${LOG} TabGroupCreate hook: applying restore state to ${existing.length} pre-existing tab-group(s)`);
+    existing.forEach(applyTabGroupRestoreState);
+  }
   console.log(`${LOG} TabGroupCreate hook installed`);
+};
+
+// Watch every tab-group's `collapsed` attribute and persist the current set
+// of collapsed labels to the pref. Re-applied on TabGroupCreate (above) so
+// the user's collapse choices survive browser restarts.
+export const setupCollapsedStatePersistence = () => {
+  if (window._zaoCollapseObserverInstalled) return;
+  window._zaoCollapseObserverInstalled = true;
+
+  const persist = (group) => {
+    const label = group.getAttribute?.("label");
+    if (!label) return;
+    const isCollapsed = group.hasAttribute("collapsed");
+    const set = readCollapsedGroupsPref();
+    const had = set.has(label);
+    if (isCollapsed && !had) set.add(label);
+    else if (!isCollapsed && had) set.delete(label);
+    else return; // no change
+    writeCollapsedGroupsPref(set);
+  };
+
+  const watch = (group) => {
+    if (group._zaoCollapseAttrObs) return;
+    const obs = new MutationObserver((muts) => {
+      for (const m of muts) {
+        if (m.type === "attributes" && m.attributeName === "collapsed") persist(group);
+      }
+    });
+    obs.observe(group, { attributes: true, attributeFilter: ["collapsed"] });
+    group._zaoCollapseAttrObs = obs;
+  };
+
+  // Existing tab-groups
+  document.querySelectorAll("tab-group").forEach(watch);
+
+  // Future tab-groups (e.g. session restore, user-created via "New Group")
+  const containerObs = new MutationObserver((muts) => {
+    for (const m of muts) {
+      for (const n of m.addedNodes) {
+        if (n.nodeType !== 1) continue;
+        if (n.tagName?.toLowerCase() === "tab-group") watch(n);
+        else n.querySelectorAll?.("tab-group").forEach(watch);
+      }
+    }
+  });
+  containerObs.observe(document.body || document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  console.log(`${LOG} collapsed-state persistence observer installed`);
 };
 
 // ─── Pref observers ──────────────────────────────────────────────────────────

--- a/modules/click-handler.mjs
+++ b/modules/click-handler.mjs
@@ -3,7 +3,7 @@
 //            → Pass 1 → apply → ungrouped-to-top → sync colors.
 
 import { CONFIG, LOG, BUILD_VERSION } from "./config.mjs";
-// CONFIG also exposes the pref name we read inside the AI gate diagnostic below.
+// (CONFIG is used inside the click pipeline for thresholds, pref names, and DOM ids.)
 import { loadRules, readSkipDomainsPref, isMinimalStyle, isStrictRulesEnforced, getAIEngine, getOllamaHost, getOllamaModel, getAINewGroupBehavior, getAIExistingBehavior } from "./rules.mjs";
 import { getEligibleTabs } from "./tabs.mjs";
 import {
@@ -15,7 +15,7 @@ import {
   syncAllGroupColors,
 } from "./groups.mjs";
 import { runPass1, applyPass1, matchesDomain } from "./pass1.mjs";
-import { runPass2, applyPass2 } from "./ai.mjs";
+import { runPass2, runPass2Fresh, applyPass2 } from "./ai.mjs";
 import { checkOllamaReady, reportOllamaError, normalizeOllamaHost, runPass2Ollama, runPass2OllamaFresh, classifyExistingGroupsBatch } from "./ollama.mjs";
 import { showPreviewModal } from "./preview-modal.mjs";
 
@@ -126,16 +126,20 @@ export const handleOrganizeClick = async () => {
   // 5. Pass 1 matching + diagnostic logging.
   const { assignments, byGroup, unmatched, alreadyCorrect } = runPass1(tabs, rules);
 
-  // Always-visible diagnostic (outside the collapsed group below) so we can see
-  // the AI gate decision regardless of console group expansion state.
+  // Read AI engine + new-group behavior up-front so the Pass 1 diagnostic table
+  // below can show the action that would follow given the current mode.
   const aiEngine = getAIEngine();
-  const newGroupBehavior = aiEngine === "ollama" ? getAINewGroupBehavior() : "";
+  // Read the new-group behavior for any AI engine — local now also supports
+  // fresh-categories / identify-only (clustering into hostname-named groups).
+  // The other behaviors (auto-add / always-add / prompt) imply LLM-style
+  // semantic naming and are no-ops on local; we just fall through to the
+  // existing-only path in that case.
+  const newGroupBehavior = aiEngine !== "off" ? getAINewGroupBehavior() : "";
   const isFreshMode = newGroupBehavior === "fresh-categories";
   const isIdentifyOnly = newGroupBehavior === "identify-only";
   // Both fresh and identify-only reclassify ALL tabs and bypass Pass 1's apply.
   // Identify-only also gates the apply step on user confirmation via modal.
   const isFreshLike = isFreshMode || isIdentifyOnly;
-  console.log(`${LOG} AI gate (pre-pass): engine=${aiEngine}${newGroupBehavior ? `, new-group=${newGroupBehavior}` : ""}, unmatched=${unmatched.length}`);
 
   // Wrapped in try/finally so console.groupEnd always runs even if a later step
   // throws — otherwise the next click's logs would nest inside this group.
@@ -234,18 +238,74 @@ export const handleOrganizeClick = async () => {
             reportOllamaError(host, model, status);
             pass2 = { assignedToExisting: [], newGroups: [], skipped: isFreshMode ? tabs : unmatched };
           } else {
-            console.log(`${LOG} Ollama ready at ${normalizeOllamaHost(host)} (model: ${model})`);
+            console.debug(`${LOG} Ollama ready at ${normalizeOllamaHost(host)} (model: ${model})`);
             const t0 = performance.now();
             if (isFreshLike) {
               pass2 = await runPass2OllamaFresh(tabs);
             } else {
               pass2 = await runPass2Ollama(unmatched, rules);
+              // Stickiness for rule-considering modes: don't let the AI
+              // pull a tab OUT of a user-organized group INTO a brand-new
+              // AI-invented category. Reclassifying into an EXISTING group
+              // (assignedToExisting) is still allowed — that's the wand
+              // correcting wrong placement. Fresh / identify-only opt out
+              // of this by design (those modes are full re-orgs).
+              if (pass2.newGroups?.length) {
+                const displaced = [];
+                for (const g of pass2.newGroups) {
+                  const stays = [];
+                  for (const t of g.tabs) {
+                    if (t.currentGroup) displaced.push(t);
+                    else stays.push(t);
+                  }
+                  g.tabs = stays;
+                }
+                pass2.newGroups = pass2.newGroups.filter((g) => g.tabs.length > 0);
+                if (displaced.length > 0) {
+                  console.log(
+                    `${LOG} stickiness: kept ${displaced.length} already-grouped tab(s) in place rather than moving to new AI group(s):`,
+                    displaced.map((t) => `${t.hostname} (in "${t.currentGroup}")`)
+                  );
+                  pass2.skipped = [...(pass2.skipped || []), ...displaced];
+                }
+              }
             }
             console.log(`${LOG} Ollama Pass 2 took ${Math.round(performance.now() - t0)}ms`);
           }
         } else {
-          // Local engine — never runs in fresh mode; that's Ollama-only.
-          pass2 = await runPass2(unmatched, rules, workspaceId);
+          // Local engine. Two sub-paths:
+          //   - fresh-categories / identify-only: cluster ALL eligible tabs
+          //     into new groups (ignores rules). This is the ONLY Local mode
+          //     that creates new groups.
+          //   - auto-add / transient (or any other value): existing-only fit.
+          //     The dropdown's choice between auto-add vs transient feeds
+          //     getAIExistingBehavior() to decide whether the rule grows.
+          // Soft cap: very large input sets take real time on the Local engine
+          // even with chunking + dedupe. Confirm with the user before running
+          // so a 3000-tab workspace doesn't ambush them. Cancellation just
+          // produces an empty-plan pass2 result; the outer flow (color sync,
+          // settle, etc.) still runs.
+          const localInput = isFreshLike ? tabs : unmatched;
+          let cancelled = false;
+          if (localInput.length > CONFIG.AI_LOCAL_CONFIRM_THRESHOLD) {
+            const proceed = window.confirm(
+              `You have ${localInput.length} ${isFreshLike ? "" : "unmatched "}tabs.\n\n` +
+              `Running the Local AI on this many can take minutes and briefly lag the browser.\n\n` +
+              `Continue?`
+            );
+            if (!proceed) {
+              console.log(`${LOG} Pass 2 cancelled by user (soft cap at ${CONFIG.AI_LOCAL_CONFIRM_THRESHOLD})`);
+              pass2 = { assignedToExisting: [], newGroups: [], skipped: localInput };
+              cancelled = true;
+            }
+          }
+          if (!cancelled) {
+            if (isFreshLike) {
+              pass2 = await runPass2Fresh(tabs);
+            } else {
+              pass2 = await runPass2(unmatched, rules, workspaceId);
+            }
+          }
         }
         if (pass2.assignedToExisting.length > 0 || pass2.newGroups.length > 0) {
           console.log(`${LOG} Pass 2 plan: ${pass2.assignedToExisting.length} to existing group(s), ${pass2.newGroups.length} new group(s), ${pass2.skipped.length} skipped`);
@@ -264,40 +324,44 @@ export const handleOrganizeClick = async () => {
           }
 
           // Decide whether to show the Plan Mode modal:
-          //   - Plan Mode (identify-only) → always show (it IS the modal mode)
+          //   - Plan Mode (identify-only) → always show (it IS the modal mode);
+          //     applies to BOTH engines (local Fresh is hostname-named so the
+          //     modal lets the user rename / re-assign before applying)
           //   - Auto-add / Always-add → show so user can veto rule mutations
-          //     before they hit the rules table
+          //     before they hit the rules table. Ollama-only — those modes imply
+          //     LLM-style semantic naming.
           //   - Transient (either) → no modal (it's just a temp move per user)
           //   - Prompt → no modal (Zen handles per-group via its own edit modal)
           //   - Fresh-categories → no modal (no rule mutations happen here)
           let planToApply = pass2;
           let showModal = false;
           let modalReason = "";
-          if (aiEngine === "ollama") {
-            if (isIdentifyOnly) {
+          if (isIdentifyOnly) {
+            showModal = true;
+            modalReason = "Plan Mode";
+          } else if (aiEngine === "ollama" && !isFreshMode && newGroupBehavior !== "prompt") {
+            const existingBehavior = getAIExistingBehavior();
+            const flags = [];
+            if (existingBehavior === "always-add") flags.push("always-add");
+            if (newGroupBehavior === "auto-add") flags.push("auto-add");
+            if (flags.length > 0) {
               showModal = true;
-              modalReason = "Plan Mode";
-            } else if (!isFreshMode && newGroupBehavior !== "prompt") {
-              const existingBehavior = getAIExistingBehavior();
-              const flags = [];
-              if (existingBehavior === "always-add") flags.push("always-add");
-              if (newGroupBehavior === "auto-add") flags.push("auto-add");
-              if (flags.length > 0) {
-                showModal = true;
-                modalReason = flags.join(" + ");
-              }
+              modalReason = flags.join(" + ");
             }
           }
 
           if (showModal) {
-            console.log(`${LOG} Plan Mode modal opening (${modalReason}) — user must confirm before rules mutate`);
+            console.debug(`${LOG} Plan Mode modal opening (${modalReason}) — user must confirm before rules mutate`);
             planToApply = await showPreviewModal({
               plan: pass2,
               // "Re-assign to new" — open-ended clustering for pending tabs.
-              // Always uses the fresh classifier so the model isn't biased
-              // by existing-rule context (the user explicitly wants NEW).
+              // Always uses a fresh classifier so the model isn't biased by
+              // existing-rule context (the user explicitly wants NEW). Routes
+              // to whichever engine the user picked.
               onReassignToNew: async (pendingTabs) => {
-                const r = await runPass2OllamaFresh(pendingTabs);
+                const r = aiEngine === "local"
+                  ? await runPass2Fresh(pendingTabs)
+                  : await runPass2OllamaFresh(pendingTabs);
                 return { newGroups: r.newGroups, skipped: r.skipped };
               },
               // "Re-assign to planned" — constrained-vocabulary classification.

--- a/modules/config.mjs
+++ b/modules/config.mjs
@@ -15,7 +15,7 @@ export const LOG = "[ZenTabWand]";
 // Build tag — mirrors theme.json's `version` for shipped releases, and gets a
 // `+tag.N` suffix for in-progress iterative builds so the Browser Console
 // reveals which build is actually running (vs. a stale module cache).
-export const BUILD_VERSION = "1.0.1";
+export const BUILD_VERSION = "1.0.2";
 
 export const CONFIG = {
   // Init polling — wait for gBrowser/gZenWorkspaces/separator to appear at startup.
@@ -43,6 +43,11 @@ export const CONFIG = {
 
   RULES_PREF: "extensions.zen-auto-organize.rules-json",
   SKIP_DOMAINS_PREF: "extensions.zen-auto-organize.skip-domains-json",
+  // Set of tab-group LABELS currently collapsed. JSON-encoded string array.
+  // Updated on every collapse-toggle; re-applied on every TabGroupCreate so
+  // session restore preserves collapsed/expanded state across browser
+  // restarts (Zen's own session save loses the `collapsed` attribute).
+  COLLAPSED_GROUPS_PREF: "extensions.zen-auto-organize.collapsed-groups-json",
   MINIMAL_STYLE_PREF: "extensions.zen-auto-organize.minimal-style",
   STRICT_RULES_PREF: "extensions.zen-auto-organize.strict-rules",
 
@@ -56,6 +61,10 @@ export const CONFIG = {
   AI_OLLAMA_HOST_PREF: "extensions.zen-auto-organize.ai-ollama-host",
   AI_OLLAMA_MODEL_PREF: "extensions.zen-auto-organize.ai-ollama-model",
   AI_OLLAMA_WARMUP_PREF: "extensions.zen-auto-organize.ai-ollama-warmup",
+  // One-shot flags: set true after the user dismisses the first-time AI
+  // engine resource-warning modal. Each engine has its own acknowledgement.
+  OLLAMA_ACKNOWLEDGED_PREF: "extensions.zen-auto-organize.ollama-acknowledged",
+  LOCAL_ACKNOWLEDGED_PREF: "extensions.zen-auto-organize.local-acknowledged",
   AI_OLLAMA_HOST_DEFAULT: "http://localhost:11434",
   AI_OLLAMA_MODEL_DEFAULT: "qwen2.5:1.5b",
 
@@ -66,7 +75,19 @@ export const CONFIG = {
   // local AI only fires on slam dunks.
   AI_EXISTING_GROUP_THRESHOLD: 0.65,    // min (raw + boost) cosine sim for "tab belongs to existing group"
   AI_EXISTING_GROUP_BOOST: 0.10,        // added to existing-group sim
-  AI_EMBEDDING_BATCH_SIZE: 5,           // tabs per parallel embedding batch
+  AI_EMBEDDING_BATCH_SIZE: 5,           // tabs per parallel embedding batch (small-workspace default)
+
+  // Local-AI chunking. When the count of unmatched tabs to embed exceeds the
+  // chunking threshold, the engine switches to a more conservative pipeline:
+  //   - Hostname dedupe: only one tab per unique hostname is embedded; the
+  //     resulting embedding is reused for all siblings on the same domain.
+  //   - Yield between batches: `await setTimeout(0)` after each batch keeps
+  //     the event loop alive so the browser doesn't freeze.
+  // Together these keep the AI pass responsive on very large workspaces.
+  AI_LOCAL_CHUNK_THRESHOLD: 75,         // unmatched count above which chunking + dedupe kicks in
+  AI_LOCAL_BATCH_SIZE_PREF: "extensions.zen-auto-organize.ai-local-batch-size",
+  AI_LOCAL_BATCH_SIZE_DEFAULT: 30,      // pref default; user-overridable
+  AI_LOCAL_CONFIRM_THRESHOLD: 500,      // unmatched count above which a confirmation modal is shown before Pass 2
 
   // chrome:// URLs served by Sine from this mod's directory.
   RULES_URL: "chrome://sine/content/zen-tab-wand/rules.json",

--- a/modules/groups.mjs
+++ b/modules/groups.mjs
@@ -34,12 +34,48 @@ export const findExistingGroup = (name, workspaceId) => {
   }
 };
 
+// Zen toggles the `collapsed` attribute as an HTML boolean: present (with
+// empty-string value) = collapsed, absent = expanded. The previous check
+// of `=== "true"` never matched and silently no-op'd. We also use the
+// property setter when available, because Firefox's MozTabbrowserTabGroup
+// setter both flips the attribute AND clears `aria-hidden` on inner tabs —
+// crucial for our collapse CSS rule which keys off aria-hidden.
+//
+// Returns true if the group WAS collapsed (caller can decide to re-collapse
+// after its work is done so newly-added tabs join the collapse properly).
 export const expandIfCollapsed = (groupEl) => {
+  if (!groupEl?.isConnected) return false;
+  if (!groupEl.hasAttribute("collapsed")) return false;
+  let didFlip = false;
+  try { groupEl.collapsed = false; didFlip = true; } catch {}
+  if (!didFlip) {
+    try { groupEl.removeAttribute("collapsed"); } catch {}
+    // Property setter wasn't available; manually clear aria-hidden so the
+    // newly-visible tabs don't stay invisibly hidden by our CSS rule.
+    for (const tab of groupEl.querySelectorAll("tab[aria-hidden]")) {
+      try { tab.removeAttribute("aria-hidden"); } catch {}
+    }
+  }
+  const labelEl = groupEl.querySelector(".tab-group-label");
+  if (labelEl) labelEl.setAttribute("aria-expanded", "true");
+  return true;
+};
+
+// Inverse of expandIfCollapsed — set collapsed back on. Uses the property
+// setter so Firefox properly re-applies aria-hidden to ALL current tabs
+// (including any that were added while the group was expanded).
+export const collapseGroup = (groupEl) => {
   if (!groupEl?.isConnected) return;
-  if (groupEl.getAttribute("collapsed") === "true") {
-    groupEl.setAttribute("collapsed", "false");
-    const labelEl = groupEl.querySelector(".tab-group-label");
-    if (labelEl) labelEl.setAttribute("aria-expanded", "true");
+  let didFlip = false;
+  try { groupEl.collapsed = true; didFlip = true; } catch {}
+  if (!didFlip) {
+    try { groupEl.setAttribute("collapsed", ""); } catch {}
+    // Fallback aria-hidden if property setter wasn't available
+    for (const tab of groupEl.querySelectorAll("tab")) {
+      if (!tab.hasAttribute("selected")) {
+        try { tab.setAttribute("aria-hidden", "true"); } catch {}
+      }
+    }
   }
 };
 
@@ -58,7 +94,7 @@ export const applyGroupColor = (groupEl, color) => {
       groupEl.style.removeProperty("--tab-group-color-pale");
       groupEl.style.removeProperty("--tab-group-line-color");
       groupEl.color = color;
-      console.log(`${LOG} colored "${groupEl.getAttribute("label")}" → ${color} (named)`);
+      console.debug(`${LOG} colored "${groupEl.getAttribute("label")}" → ${color} (named)`);
     } catch (e) {
       console.error(`${LOG} group.color setter failed:`, e);
     }
@@ -73,7 +109,7 @@ export const applyGroupColor = (groupEl, color) => {
       groupEl.style.setProperty("--tab-group-color-invert", invert, "important");
       groupEl.style.setProperty("--tab-group-color-pale", pale, "important");
       groupEl.style.setProperty("--tab-group-line-color", color, "important");
-      console.log(`${LOG} colored "${groupEl.getAttribute("label")}" → ${color} (hex)`);
+      console.debug(`${LOG} colored "${groupEl.getAttribute("label")}" → ${color} (hex)`);
     } catch (e) {
       console.error(`${LOG} style.setProperty failed:`, e);
     }

--- a/modules/ollama-prompts.mjs
+++ b/modules/ollama-prompts.mjs
@@ -90,6 +90,7 @@ For each tab, pick a single label that is one of:
 - "skipped" if the tab really doesn't fit with anything
 
 Guidance:
+- Use an existing label only when the tab is the SAME KIND of thing as that label's example domains — same service, same provider, or a near-equivalent substitute. The example domains define what the label means. Do NOT use an existing label as a generic catch-all because its name sounds related. If no existing label closely fits, create a new label or "skipped".
 - Several tabs about the same topic should share the SAME label. For example, three different gaming sites (news, marketplace, ranking) all belong under ONE shared label.
 - Aim for at most 1-2 new labels per batch. Broad buckets beat narrow ones.
 - A new label that covers only one tab is unusual — only pick one if that tab is clearly its own distinct topic with no siblings here.
@@ -112,8 +113,14 @@ export const buildFreshPrompt = (tabs, snippets) =>
 Tabs:
 ${renderTabList(tabs, snippets)}
 
+Each tab line may include a Summary with bracketed signals:
+- [type: ...] — the page type (article, video, product, profile, website, book, music.song, etc.). This is the strongest signal for intent: 'article' tabs are reading, 'video' tabs are watching, 'product' tabs are shopping.
+- [site: ...] — the site's brand name (e.g. "BBC News", "Vimeo").
+- [topic: ...] — the page's main heading.
+
 Guidelines:
-- Group tabs that share a topic under ONE category name. Several gaming sites all get the same gaming category, several retailers all get the same shopping category, etc.
+- Use the signals above to infer what the user is DOING with each tab, not just what website they're on. Prefer category names that reflect that intent — "Reading", "Watching", "Research", "Shopping", "Work tools" — over narrow topic labels like "BBC", "Vimeo Videos".
+- When multiple tabs share a [type:] or describe the same underlying activity, they belong in the same category even if their hostnames differ.
 - Pick short, broad category names (1-3 words, Title Case).
 - Aim for a small total number of categories — broad buckets beat narrow ones. Most workspaces have 3-6 categories total.
 - A category should have at least 2 tabs. Single-tab categories are usually wrong.

--- a/modules/ollama-transport.mjs
+++ b/modules/ollama-transport.mjs
@@ -13,9 +13,13 @@ import { showToast } from "./ui-toast.mjs";
 
 const PING_TIMEOUT_MS = 3000;
 // Classification calls: generous because the FIRST request after the daemon
-// has been idle includes a model warm-up (~5–10s for 1.5B on CPU/GPU, longer
-// for bigger models). Subsequent calls are sub-second.
-const GENERATE_TIMEOUT_MS = 60000;
+// has been idle includes a model warm-up (~5–10s for 1.5B on CPU/GPU, much
+// longer for 7B+). The actual inference time also scales with prompt size —
+// 100+ unique tabs classified in a single prompt against a 7B model can run
+// ~30–90s even when warm. 180s covers cold-load + large workspaces with
+// headroom; sub-second once warm on small workloads, so this only kicks in
+// as an upper bound.
+const GENERATE_TIMEOUT_MS = 180000;
 const WARMUP_TIMEOUT_MS = 30000;
 
 // Returns the keep_alive fragment to spread into a generate-call body —

--- a/modules/ollama.mjs
+++ b/modules/ollama.mjs
@@ -63,7 +63,7 @@ export const classifyExistingGroupsBatch = async (unmatched, rules, host, model)
     throw new Error("Ollama classify: returned non-object JSON");
   }
 
-  console.log(`${LOG} Ollama raw classification:`, parsed);
+  console.debug(`${LOG} Ollama raw classification:`, parsed);
 
   // Validate categories — small models occasionally hallucinate names that
   // weren't in the list. Case-insensitive match to be forgiving of "shopping"
@@ -103,7 +103,7 @@ const clusterUnmatchedNewGroups = async (leftover, host, model) => {
   const r = await ollamaGenerateJson(host, model, prompt);
   if (!r.ok) throw new Error(`Ollama cluster: ${r.error}`);
 
-  console.log(`${LOG} Ollama raw clustering:`, r.parsed);
+  console.debug(`${LOG} Ollama raw clustering:`, r.parsed);
 
   const validIdx = (i) => Number.isFinite(i) && i >= 0 && i < leftover.length;
   const seen = new Set();
@@ -165,13 +165,19 @@ export const unifiedClassifyOllama = async (unmatched, rules, host, model) => {
   // and any failure (auth, timeout, non-HTML, no meta tag) returns "" so the
   // tab just falls back to title-only context — never blocks classification.
   const t0 = performance.now();
-  const snippets = await Promise.all(deduped.map((t) => fetchPageSnippet(t.url)));
+  const snippets = await Promise.all(deduped.map((t) => {
+    const url = t.url || "";
+    if (!url.startsWith("http://") && !url.startsWith("https://")) return "";
+    return fetchPageSnippet(url);
+  }));
   const hit = snippets.filter((s) => s).length;
   console.log(`${LOG} Ollama: fetched page snippets for ${hit}/${deduped.length} tab(s) in ${Math.round(performance.now() - t0)}ms`);
+  console.groupCollapsed(`${LOG} Ollama snippet detail (collapse)`);
   console.log(
     `${LOG} Ollama snippet detail:\n` +
     deduped.map((t, i) => `  ${t.hostname || "(no host)"} → ${snippets[i] ? `"${snippets[i].slice(0, 80)}${snippets[i].length > 80 ? "…" : ""}"` : "(no snippet)"}`).join("\n")
   );
+  console.groupEnd();
 
   const prompt = buildUnifiedPrompt(rules, deduped, snippets);
   const r = await ollamaGenerateJson(host, model, prompt);
@@ -181,7 +187,7 @@ export const unifiedClassifyOllama = async (unmatched, rules, host, model) => {
     throw new Error("Ollama unified: returned non-object JSON");
   }
 
-  console.log(`${LOG} Ollama unified classification:`, parsed);
+  console.debug(`${LOG} Ollama unified classification:`, parsed);
 
   // Lookup table for canonicalizing an existing rule name (case-insensitive).
   const ruleNameByLower = new Map(
@@ -221,10 +227,79 @@ export const unifiedClassifyOllama = async (unmatched, rules, host, model) => {
   // 1-tab survivors are honored as the model's intent rather than dropped.
   let newGroups = [...newGroupsByKey.values()];
   if (newGroups.length >= 2) {
-    newGroups = await mergeNewCategoriesPass(newGroups, host, model);
+    try {
+      newGroups = await mergeNewCategoriesPass(newGroups, host, model);
+    } catch (e) {
+      console.warn(`${LOG} Ollama merge-pass errored — keeping un-merged groups:`, e);
+    }
   }
+  // 3rd phase — fuzzy name dedupe (catches what the LLM merge missed).
+  newGroups = dedupeSimilarNewGroups(newGroups);
 
   return { assignedToExisting, newGroups, skipped };
+};
+
+// ─── 3rd-phase name-based dedupe ─────────────────────────────────────────────
+// Catches near-identical names the LLM merge pass missed. Symptoms we've seen
+// in the wild that motivated this:
+//   - "Content Unavailable" + "Content Unavailability"     (morphology drift)
+//   - "Communication Apps" + "Communication Tools"         (different suffix)
+//   - "Project Management" + "Project Management Tools"    (substring extra)
+// Strategy: normalize each name to a stem + drop trailing generic words
+// (Tools / Apps / Platforms / ...), then merge groups with the same normalized
+// form. The canonical name kept is whichever group appears FIRST in the input
+// — typically the LLM's "cleaner" first proposal.
+
+const TRAILING_GENERICS = new Set([
+  "tools", "tool", "apps", "app", "platforms", "platform",
+  "services", "service", "sites", "site", "websites", "website",
+  "products", "product", "stuff", "things",
+]);
+
+const lightStem = (word) =>
+  word
+    .replace(/(ability|ibility)$/i, "")
+    .replace(/(able|ible)$/i, "")
+    .replace(/(ation|ization)$/i, "")
+    .replace(/(ing)$/i, "")
+    .replace(/(ies)$/i, "y")
+    .replace(/(s)$/i, "");
+
+const normalizeNameForDedupe = (name) => {
+  const words = String(name || "")
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+  while (words.length > 1 && TRAILING_GENERICS.has(words[words.length - 1])) {
+    words.pop();
+  }
+  return words.map(lightStem).join(" ");
+};
+
+const dedupeSimilarNewGroups = (newGroups) => {
+  if (!newGroups || newGroups.length < 2) return newGroups || [];
+  const byNorm = new Map(); // normalized → index in `out`
+  const out = [];
+  let mergedCount = 0;
+  for (const g of newGroups) {
+    const norm = normalizeNameForDedupe(g.name);
+    if (byNorm.has(norm)) {
+      const existing = out[byNorm.get(norm)];
+      console.log(`${LOG} Ollama 3rd-pass dedupe: "${g.name}" → "${existing.name}" (normalized match: "${norm}")`);
+      existing.tabs.push(...g.tabs);
+      mergedCount++;
+    } else {
+      byNorm.set(norm, out.length);
+      out.push({ ...g });
+    }
+  }
+  if (mergedCount > 0) {
+    console.log(`${LOG} Ollama 3rd-pass dedupe: collapsed ${mergedCount} similar-named cluster(s) (${newGroups.length} → ${out.length})`);
+  }
+  return out;
 };
 
 // ─── Merge pass ──────────────────────────────────────────────────────────────
@@ -249,7 +324,8 @@ const mergeNewCategoriesPass = async (newGroups, host, model) => {
     return newGroups;
   }
 
-  console.log(`${LOG} Ollama merge-pass took ${Math.round(performance.now() - t0)}ms; raw response:`, parsed);
+  console.log(`${LOG} Ollama merge-pass took ${Math.round(performance.now() - t0)}ms`);
+  console.debug(`${LOG} Ollama merge-pass raw response:`, parsed);
 
   // Schema: { "Original Name": "Target Name", ... } — for each original, the
   // model picks a target. Originals sharing a target get merged into one
@@ -325,66 +401,82 @@ export const runPass2OllamaFresh = async (allTabs) => {
   const host = getOllamaHost();
   const model = getOllamaModel();
 
-  // Dedup duplicate tabs (same hostname + title) — same reasoning as the
-  // unified path. Avoids inconsistent answers across copies of the same tab.
-  const dedupKey = (t) => `${t.hostname || ""}\x00${t.title || ""}`;
-  const dedupIndexByKey = new Map();
-  const deduped = [];
-  const origToDeduped = allTabs.map((t) => {
-    const k = dedupKey(t);
-    if (dedupIndexByKey.has(k)) return dedupIndexByKey.get(k);
-    const i = deduped.length;
-    dedupIndexByKey.set(k, i);
-    deduped.push(t);
-    return i;
-  });
-  if (deduped.length < allTabs.length) {
-    console.log(`${LOG} Ollama fresh: deduplicated ${allTabs.length} tabs → ${deduped.length} unique`);
-  }
-
-  const t0 = performance.now();
-  const snippets = await Promise.all(deduped.map((t) => fetchPageSnippet(t.url)));
-  const hit = snippets.filter((s) => s).length;
-  console.log(`${LOG} Ollama fresh: fetched snippets for ${hit}/${deduped.length} tab(s) in ${Math.round(performance.now() - t0)}ms`);
-
-  const prompt = buildFreshPrompt(deduped, snippets);
-  const r = await ollamaGenerateJson(host, model, prompt);
-  if (!r.ok) {
-    console.error(`${LOG} Ollama fresh failed (${r.errorType}):`, r.error);
-    showToast(`Ollama fresh classification failed: ${r.error}`);
-    return { ...empty, skipped: allTabs, failed: r.error };
-  }
-  const parsed = r.parsed;
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    console.warn(`${LOG} Ollama fresh: non-object JSON, returning all as skipped`);
-    return { ...empty, skipped: allTabs };
-  }
-
-  console.log(`${LOG} Ollama fresh classification:`, parsed);
-
-  const newGroupsByKey = new Map();
-  const skipped = [];
-  for (let i = 0; i < allTabs.length; i++) {
-    const dedupIdx = origToDeduped[i];
-    const value = parsed[dedupIdx] !== undefined ? parsed[dedupIdx] : parsed[String(dedupIdx)];
-    const raw = stripMetaPrefix(value == null ? "" : String(value).trim());
-    const lower = raw.toLowerCase();
-    if (!raw || lower === "skipped" || lower === "none") {
-      skipped.push(allTabs[i]);
-      continue;
+  try {
+    // Dedup duplicate tabs (same hostname + title) — same reasoning as the
+    // unified path. Avoids inconsistent answers across copies of the same tab.
+    const dedupKey = (t) => `${t.hostname || ""}\x00${t.title || ""}`;
+    const dedupIndexByKey = new Map();
+    const deduped = [];
+    const origToDeduped = allTabs.map((t) => {
+      const k = dedupKey(t);
+      if (dedupIndexByKey.has(k)) return dedupIndexByKey.get(k);
+      const i = deduped.length;
+      dedupIndexByKey.set(k, i);
+      deduped.push(t);
+      return i;
+    });
+    if (deduped.length < allTabs.length) {
+      console.log(`${LOG} Ollama fresh: deduplicated ${allTabs.length} tabs → ${deduped.length} unique`);
     }
-    if (!newGroupsByKey.has(lower)) {
-      newGroupsByKey.set(lower, { name: raw, tabs: [] });
-    }
-    newGroupsByKey.get(lower).tabs.push(allTabs[i]);
-  }
 
-  // Run the merge pass to consolidate over-specialized categories. No
-  // post-filter — we trust whatever survives. See unifiedClassifyOllama
-  // for the rationale (singletons honor model intent rather than discard it).
-  let newGroups = [...newGroupsByKey.values()];
-  if (newGroups.length >= 2) {
-    newGroups = await mergeNewCategoriesPass(newGroups, host, model);
+    const t0 = performance.now();
+    const snippets = await Promise.all(deduped.map((t) => {
+      const url = t.url || "";
+      if (!url.startsWith("http://") && !url.startsWith("https://")) return "";
+      return fetchPageSnippet(url);
+    }));
+    const hit = snippets.filter((s) => s).length;
+    console.log(`${LOG} Ollama fresh: fetched snippets for ${hit}/${deduped.length} tab(s) in ${Math.round(performance.now() - t0)}ms`);
+
+    const prompt = buildFreshPrompt(deduped, snippets);
+    const r = await ollamaGenerateJson(host, model, prompt);
+    if (!r.ok) {
+      console.error(`${LOG} Ollama fresh failed (${r.errorType}):`, r.error);
+      showToast(`Ollama fresh classification failed: ${r.error}`);
+      return { ...empty, skipped: allTabs, failed: r.error };
+    }
+    const parsed = r.parsed;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      console.warn(`${LOG} Ollama fresh: non-object JSON, returning all as skipped`);
+      return { ...empty, skipped: allTabs };
+    }
+
+    console.debug(`${LOG} Ollama fresh classification:`, parsed);
+
+    const newGroupsByKey = new Map();
+    const skipped = [];
+    for (let i = 0; i < allTabs.length; i++) {
+      const dedupIdx = origToDeduped[i];
+      const value = parsed[dedupIdx] !== undefined ? parsed[dedupIdx] : parsed[String(dedupIdx)];
+      const raw = stripMetaPrefix(value == null ? "" : String(value).trim());
+      const lower = raw.toLowerCase();
+      if (!raw || lower === "skipped" || lower === "none") {
+        skipped.push(allTabs[i]);
+        continue;
+      }
+      if (!newGroupsByKey.has(lower)) {
+        newGroupsByKey.set(lower, { name: raw, tabs: [] });
+      }
+      newGroupsByKey.get(lower).tabs.push(allTabs[i]);
+    }
+
+    // Run the merge pass to consolidate over-specialized categories. No
+    // post-filter — we trust whatever survives. See unifiedClassifyOllama
+    // for the rationale (singletons honor model intent rather than discard it).
+    let newGroups = [...newGroupsByKey.values()];
+    if (newGroups.length >= 2) {
+      try {
+        newGroups = await mergeNewCategoriesPass(newGroups, host, model);
+      } catch (e) {
+        console.warn(`${LOG} Ollama merge-pass errored — keeping un-merged groups:`, e);
+      }
+    }
+    // 3rd phase — fuzzy name dedupe (catches what the LLM merge missed).
+    newGroups = dedupeSimilarNewGroups(newGroups);
+    return { assignedToExisting: [], newGroups, skipped };
+  } catch (e) {
+    console.error(`${LOG} Ollama fresh classification failed:`, e);
+    showToast(`Ollama fresh classification failed: ${e.message || e}`);
+    return { ...empty, skipped: allTabs, failed: e.message || String(e) };
   }
-  return { assignedToExisting: [], newGroups, skipped };
 };

--- a/modules/pass1.mjs
+++ b/modules/pass1.mjs
@@ -2,7 +2,7 @@
 // Pure logic over rules + tab info; applyPass1 mutates the DOM via gBrowser APIs.
 
 import { LOG } from "./config.mjs";
-import { findExistingGroup, expandIfCollapsed, applyGroupColor, findSafeInsertAnchor } from "./groups.mjs";
+import { findExistingGroup, expandIfCollapsed, collapseGroup, applyGroupColor, findSafeInsertAnchor } from "./groups.mjs";
 
 // Match a hostname against a single rule-domain pattern.
 //   "host.com"    matches the bare host AND any subdomain
@@ -91,7 +91,11 @@ export const applyPass1 = (byGroup, workspaceId, rules) => {
     if (existing?.isConnected) {
       console.log(`${LOG} reusing existing group "${groupName}" (${tabsForGroup.length} tab(s) to move in)`);
       try {
-        expandIfCollapsed(existing);
+        // Remember if the group was collapsed BEFORE we touched it. If so,
+        // we re-collapse after adding the new tabs so the user's collapse
+        // state isn't lost AND the new tabs get properly aria-hidden'd
+        // via the property setter on collapse.
+        const wasCollapsed = expandIfCollapsed(existing);
         for (const tab of tabsForGroup) {
           if (!tab.isConnected) continue;
           if (tab.closest("tab-group") === existing) continue;
@@ -99,6 +103,13 @@ export const applyPass1 = (byGroup, workspaceId, rules) => {
           movedToExisting++;
         }
         if (colorByName.has(groupName)) applyGroupColor(existing, colorByName.get(groupName));
+        if (wasCollapsed) {
+          // Defer one tick so Firefox's tab-insertion bookkeeping completes
+          // before we collapse — otherwise the new tab's aria-hidden may
+          // not be set in the same paint.
+          const groupRef = existing;
+          setTimeout(() => collapseGroup(groupRef), 0);
+        }
       } catch (e) {
         console.error(`${LOG} error moving tabs into "${groupName}":`, e);
         errors.push({ group: groupName, error: e.message });

--- a/modules/prefs-ui.mjs
+++ b/modules/prefs-ui.mjs
@@ -120,6 +120,48 @@ const findPrefRow = (dialog, prefName) => {
   return dialog.querySelector(`#${CSS.escape(id)}`);
 };
 
+// Subset of new-group-behavior values that are meaningful on the Local engine.
+// Mirrors the same 3-way pattern as the existing-behavior dropdown:
+//   - auto-add        → save the cluster as a rule (hostname-derived name)
+//   - transient       → apply the move, don't write a rule
+//   - fresh-categories → re-tidy ALL tabs into clusters, ignoring rules
+// The other Ollama values (prompt / identify-only) require LLM-style semantic
+// output (Zen edit modal expects a meaningful name; Plan Mode review is only
+// useful when the names mean something abstract) so they're hidden on Local.
+const LOCAL_NEW_GROUP_BEHAVIORS = new Set(["auto-add", "transient", "fresh-categories"]);
+
+// Hide individual dropdown options based on a whitelist of valid values.
+// Sine's settings page is HTML (not XUL), so it renders dropdowns as either
+// native <option> elements OR custom elements (e.g. <li> with data-value).
+// We try multiple selectors and report what we found so a missing-selector
+// case is debuggable.
+const filterDropdownOptions = (row, validValues) => {
+  if (!row) return;
+  // Try every selector we've ever seen Sine use. value-bearing children only.
+  const items = [
+    ...row.querySelectorAll("option"),
+    ...row.querySelectorAll("menuitem"),
+    ...row.querySelectorAll("[data-value]"),
+    ...row.querySelectorAll('[role="option"]'),
+  ];
+  if (items.length === 0) {
+    console.warn(
+      `${LOG} filterDropdownOptions: NO option-like children under row`,
+      row,
+      "innerHTML sample:",
+      (row.innerHTML || "").slice(0, 400)
+    );
+    return;
+  }
+  for (const item of items) {
+    const v = item.getAttribute("value") || item.getAttribute("data-value");
+    if (v == null) continue;
+    const allow = validValues.has(v);
+    item.hidden = !allow;
+    item.style.display = allow ? "" : "none";
+  }
+};
+
 const updateConditionalFields = (dialog) => {
   // Always go through getAIEngine() so unknown / empty / "None" pref values
   // normalize to "off" the same way as everywhere else in the codebase.
@@ -131,11 +173,194 @@ const updateConditionalFields = (dialog) => {
     row.classList.toggle("zao-pref-hidden", hidden);
   };
 
-  setHidden(findPrefRow(dialog, CONFIG.AI_EXISTING_BEHAVIOR_PREF), !isLocalOrOllama);
-  setHidden(findPrefRow(dialog, CONFIG.AI_NEW_GROUP_BEHAVIOR_PREF), engine !== "ollama");
+  // Ollama: shows BOTH the existing-behavior and new-group-behavior rows
+  //   (they govern different parts of the unified classifier).
+  // Local: ONE row only — new-group-behavior with the 3-option filter applied.
+  //   Existing-behavior is hidden because Local unifies both decisions into
+  //   the single dropdown (auto-add = grow rules; transient = don't; fresh =
+  //   re-cluster ignoring rules entirely).
+  setHidden(findPrefRow(dialog, CONFIG.AI_EXISTING_BEHAVIOR_PREF), engine !== "ollama");
+  const newGroupBehaviorRow = findPrefRow(dialog, CONFIG.AI_NEW_GROUP_BEHAVIOR_PREF);
+  setHidden(newGroupBehaviorRow, !isLocalOrOllama);
+  if (engine === "local") {
+    filterDropdownOptions(newGroupBehaviorRow, LOCAL_NEW_GROUP_BEHAVIORS);
+    // If the user previously had an Ollama-only behavior selected (e.g.
+    // prompt / identify-only), force it back to a valid Local value so the
+    // dropdown doesn't display a now-hidden selection.
+    try {
+      const current = Services.prefs.getStringPref(CONFIG.AI_NEW_GROUP_BEHAVIOR_PREF, "");
+      if (current && !LOCAL_NEW_GROUP_BEHAVIORS.has(current)) {
+        console.log(`${LOG} new-group-behavior "${current}" not valid on Local — resetting to "transient"`);
+        Services.prefs.setStringPref(CONFIG.AI_NEW_GROUP_BEHAVIOR_PREF, "transient");
+      }
+    } catch (e) {
+      console.error(`${LOG} failed to reset new-group-behavior pref:`, e);
+    }
+  } else if (engine === "ollama") {
+    // Restore all options for Ollama (whitelist matches preferences.json).
+    filterDropdownOptions(newGroupBehaviorRow,
+      new Set(["auto-add", "transient", "prompt", "fresh-categories", "identify-only"])
+    );
+  }
   setHidden(findPrefRow(dialog, CONFIG.AI_OLLAMA_HOST_PREF),        engine !== "ollama");
   setHidden(findPrefRow(dialog, CONFIG.AI_OLLAMA_MODEL_PREF),       engine !== "ollama");
   setHidden(findPrefRow(dialog, CONFIG.AI_OLLAMA_WARMUP_PREF),      engine !== "ollama");
+  setHidden(findPrefRow(dialog, CONFIG.AI_LOCAL_BATCH_SIZE_PREF),   !isLocalOrOllama);
+};
+
+// First-time AI engine warning modals.
+//
+// Each engine (Local, Ollama) has its own one-shot warning that fires when
+// the user picks it from the dropdown for the first time. Acknowledgement is
+// recorded in a per-engine pref so each modal only ever appears once.
+//
+// The modals do NOT re-fire on settings reopen — that would be too
+// aggressive. If the user ESC's, the way to re-see is to switch engines
+// off and back.
+//
+// The "I Understand" button is disabled for 3 seconds with a live countdown
+// in the label so the user has to actually read the warning before clicking.
+const COUNTDOWN_SECONDS = 3;
+
+// Build + show a warning modal. `contentNodes` are appended to the dialog
+// body in order, before the action button. `ackPref` is the pref key whose
+// boolean tracks acknowledgement (skip if true, set true on confirm).
+const showAckModal = ({ ackPref, contentNodes, logTag }) => {
+  let alreadyAck = false;
+  try { alreadyAck = Services.prefs.getBoolPref(ackPref, false); } catch {}
+  console.debug(`${LOG} [${logTag}] maybeShow called — acknowledged=${alreadyAck}`);
+  if (alreadyAck) {
+    console.debug(`${LOG} [${logTag}] skipping — already acknowledged. To re-show, unset ${ackPref} in about:config.`);
+    return;
+  }
+  if (document.querySelector(".zao-warning-dialog[open]")) {
+    console.debug(`${LOG} [${logTag}] skipping — another warning modal already open`);
+    return;
+  }
+  console.debug(`${LOG} [${logTag}] building modal`);
+
+  const modal = h("dialog", { class: "zao-warning-dialog" });
+  for (const n of contentNodes) modal.appendChild(n);
+
+  const actions = h("div", { class: "zao-warning-actions" });
+  const btn = h("button", { class: "zao-warning-confirm" });
+  btn.type = "button";
+  btn.setAttribute("disabled", "true");
+  let remaining = COUNTDOWN_SECONDS;
+  const updateLabel = () => {
+    btn.textContent = remaining > 0 ? `${remaining}  I Understand` : "I Understand";
+  };
+  updateLabel();
+  const tick = setInterval(() => {
+    remaining--;
+    if (remaining <= 0) {
+      clearInterval(tick);
+      btn.removeAttribute("disabled");
+    }
+    updateLabel();
+  }, 1000);
+
+  btn.addEventListener("click", () => {
+    if (btn.hasAttribute("disabled")) return;
+    try { Services.prefs.setBoolPref(ackPref, true); }
+    catch (e) { console.warn(`${LOG} failed to set ${ackPref}:`, e); }
+    try { modal.close(); } catch {}
+    modal.remove();
+  });
+  // On ESC / external close, stop the countdown so it doesn't keep firing
+  // against a detached DOM node.
+  modal.addEventListener("close", () => { clearInterval(tick); });
+
+  actions.appendChild(btn);
+  modal.appendChild(actions);
+  // Append to documentElement (top-level), NOT inside Sine's dialog. Nested
+  // <dialog>.showModal() doesn't reliably layer above the parent and can
+  // get clipped by its boundaries.
+  document.documentElement.appendChild(modal);
+  try {
+    modal.showModal();
+    console.debug(`${LOG} [${logTag}] modal shown`);
+  } catch (e) {
+    console.warn(`${LOG} [${logTag}] showModal() failed — falling back to confirm():`, e);
+    modal.remove();
+  }
+};
+
+const maybeShowOllamaWarning = () => {
+  const title = h("h3", { class: "zao-warning-title", text: "Heads up: Ollama runs on your machine" });
+
+  const lead = h("p", { class: "zao-warning-lead" });
+  lead.appendChild(document.createTextNode("Ollama uses your computer's "));
+  lead.appendChild(h("strong", { text: "RAM and VRAM" }));
+  lead.appendChild(document.createTextNode(" to run AI models."));
+
+  const list = h("ul", { class: "zao-warning-list" });
+
+  const li1 = h("li");
+  li1.appendChild(h("strong", { text: "Risk: " }));
+  li1.appendChild(document.createTextNode("a model too big for your hardware can slow or crash your system."));
+
+  const li2 = h("li");
+  li2.appendChild(h("strong", { text: "Safe default: " }));
+  li2.appendChild(document.createTextNode("qwen2.5:1.5b (~1 GB) — runs on most machines."));
+
+  const li3 = h("li");
+  li3.appendChild(h("strong", { text: "Going bigger? " }));
+  const link = h("a", { class: "zao-warning-link", text: "See the model guide" });
+  link.href = "https://github.com/flantig/Zen-Tab-Wand";
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  li3.appendChild(link);
+  li3.appendChild(document.createTextNode(" first."));
+
+  list.appendChild(li1);
+  list.appendChild(li2);
+  list.appendChild(li3);
+
+  showAckModal({
+    ackPref: CONFIG.OLLAMA_ACKNOWLEDGED_PREF,
+    contentNodes: [title, lead, list],
+    logTag: "ollama-warning",
+  });
+};
+
+const maybeShowLocalWarning = () => {
+  const title = h("h3", { class: "zao-warning-title", text: "Heads up: Local AI runs inside Firefox" });
+
+  const lead = h("p", { class: "zao-warning-lead" });
+  lead.appendChild(document.createTextNode("The Local engine uses "));
+  lead.appendChild(h("strong", { text: "Firefox's built-in ML model" }));
+  lead.appendChild(document.createTextNode(" — no extra setup, but it runs inside the browser."));
+
+  const list = h("ul", { class: "zao-warning-list" });
+
+  const li1 = h("li");
+  li1.appendChild(h("strong", { text: "Risk: " }));
+  li1.appendChild(document.createTextNode("with hundreds of tabs, the AI pass can briefly spike CPU and lag the browser."));
+
+  const li2 = h("li");
+  li2.appendChild(h("strong", { text: "Limited: " }));
+  li2.appendChild(document.createTextNode("only assigns tabs to existing groups. Won't invent new categories."));
+
+  const li3 = h("li");
+  li3.appendChild(h("strong", { text: "Want stronger results? " }));
+  li3.appendChild(document.createTextNode("Try Ollama for cluster-and-name. "));
+  const link = h("a", { class: "zao-warning-link", text: "See the model guide" });
+  link.href = "https://github.com/flantig/Zen-Tab-Wand";
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  li3.appendChild(link);
+  li3.appendChild(document.createTextNode("."));
+
+  list.appendChild(li1);
+  list.appendChild(li2);
+  list.appendChild(li3);
+
+  showAckModal({
+    ackPref: CONFIG.LOCAL_ACKNOWLEDGED_PREF,
+    contentNodes: [title, lead, list],
+    logTag: "local-warning",
+  });
 };
 
 // Re-run the show/hide pass whenever the engine pref flips. One observer per
@@ -147,8 +372,17 @@ const setupEnginePrefObserver = () => {
     observe(_subject, topic, data) {
       if (topic !== "nsPref:changed") return;
       if (data !== CONFIG.AI_ENGINE_PREF) return;
+      const engine = getAIEngine();
+      console.log(`${LOG} [ollama-warning] engine pref changed → "${engine}"`);
       for (const d of document.querySelectorAll(".sineItemPreferenceDialog")) {
-        if (isOurDialog(d)) { updateConditionalFields(d); break; }
+        if (isOurDialog(d)) {
+          updateConditionalFields(d);
+          // First-time engine warning. Each engine has its own one-shot
+          // acknowledgement pref; neither modal re-fires once acknowledged.
+          if (engine === "ollama") maybeShowOllamaWarning();
+          else if (engine === "local") maybeShowLocalWarning();
+          break;
+        }
       }
     },
   };
@@ -187,7 +421,10 @@ const performInject = (dialog) => {
   if (!content) return;
 
   // Seed the rules pref with defaults on first open if currently empty.
-  let initial = readRulesPref();
+  // keepIncomplete: true so a blank row the user added in a previous session
+  // (saved as `{name:"", domains:[]}`) reappears in the editor and can be
+  // filled in. The wand-click pipeline (`loadRules`) still filters these out.
+  let initial = readRulesPref({ keepIncomplete: true });
   if (!initial || initial.length === 0) {
     initial = JSON.parse(JSON.stringify(DEFAULT_RULES));
     writeRulesPref(initial);

--- a/modules/rules.mjs
+++ b/modules/rules.mjs
@@ -17,7 +17,19 @@ import { CONFIG, DEFAULT_RULES, LOG, ZEN_COLOR_NAMES, isValidHex } from "./confi
  *
  * Malformed entries are silently dropped — invalid rules don't break valid ones.
  */
-export const readRulesPref = () => {
+/**
+ * Read the rules pref.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.keepIncomplete=false]
+ *   When true, in-progress rules (empty name or empty domains) are returned
+ *   alongside complete ones. The settings widget passes this so a user can
+ *   add a blank row, close the browser, and find it still waiting to be
+ *   filled in next session. The wand-click pipeline (`loadRules`) uses the
+ *   default — incomplete rules are no-ops at apply-time anyway, but keeping
+ *   them out of the logs is cleaner.
+ */
+export const readRulesPref = ({ keepIncomplete = false } = {}) => {
   try {
     const raw = Services.prefs.getStringPref(CONFIG.RULES_PREF, "");
     if (!raw.trim()) return null;
@@ -36,9 +48,10 @@ export const readRulesPref = () => {
           if (ZEN_COLOR_NAMES.has(c) || isValidHex(c)) out.color = c;
         }
         return out;
-      })
-      .filter((r) => r.name.length > 0 && r.domains.length > 0);
-    return cleaned;
+      });
+    return keepIncomplete
+      ? cleaned
+      : cleaned.filter((r) => r.name.length > 0 && r.domains.length > 0);
   } catch (e) {
     console.warn(`${LOG} rules pref parse failed:`, e);
     return null;
@@ -74,6 +87,31 @@ export const writeSkipDomainsPref = (domains) => {
     Services.prefs.setStringPref(CONFIG.SKIP_DOMAINS_PREF, JSON.stringify(domains));
   } catch (e) {
     console.error(`${LOG} failed to write skip-domains pref:`, e);
+  }
+};
+
+// Collapsed-group persistence. Zen's session manager doesn't save the
+// `collapsed` attribute on tab-groups, so they all come back expanded after
+// a browser restart. We track which group labels were collapsed in a pref
+// and re-apply on TabGroupCreate (session restore).
+export const readCollapsedGroupsPref = () => {
+  try {
+    const raw = Services.prefs.getStringPref(CONFIG.COLLAPSED_GROUPS_PREF, "");
+    if (!raw.trim()) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr.filter((s) => typeof s === "string") : []);
+  } catch (e) {
+    console.warn(`${LOG} collapsed-groups pref parse failed:`, e);
+    return new Set();
+  }
+};
+
+export const writeCollapsedGroupsPref = (labels) => {
+  try {
+    const arr = Array.from(labels);
+    Services.prefs.setStringPref(CONFIG.COLLAPSED_GROUPS_PREF, JSON.stringify(arr));
+  } catch (e) {
+    console.error(`${LOG} failed to write collapsed-groups pref:`, e);
   }
 };
 
@@ -182,11 +220,41 @@ export const isOllamaWarmupEnabled = () => {
   }
 };
 
+// User-configurable batch size for the Local-AI chunking path. Larger values
+// = more parallel embedding calls per chunk (faster but heavier on RAM/CPU).
+// Smaller values = gentler on the system but slower overall.
+//
+// Stored as a string pref because Sine's preferences.json schema doesn't have
+// a native int type — we parse + clamp on read so any stray about:config
+// edit can't break the pipeline.
+export const getLocalAIBatchSize = () => {
+  try {
+    const raw = Services.prefs.getStringPref(
+      CONFIG.AI_LOCAL_BATCH_SIZE_PREF,
+      String(CONFIG.AI_LOCAL_BATCH_SIZE_DEFAULT),
+    );
+    const v = parseInt(raw, 10);
+    if (!Number.isFinite(v) || v < 1) return CONFIG.AI_LOCAL_BATCH_SIZE_DEFAULT;
+    return Math.min(200, Math.max(1, v));
+  } catch {
+    return CONFIG.AI_LOCAL_BATCH_SIZE_DEFAULT;
+  }
+};
+
 // What to do when AI assigns a tab to an existing rule-matched group.
 //   "always-add" — append the tab's hostname to that rule's domains (default)
 //   "transient"  — move the tab into the group, but don't touch the rule
+//
+// On the Local engine the existing-behavior row is hidden in settings — the
+// new-group-behavior dropdown drives BOTH decisions instead. Map:
+//   Auto-add  → always-add  (grow the rule)
+//   Transient → transient   (don't grow)
+//   Fresh     → transient   (Fresh ignores rules; the answer doesn't matter)
 export const getAIExistingBehavior = () => {
   try {
+    if (getAIEngine() === "local") {
+      return getAINewGroupBehavior() === "auto-add" ? "always-add" : "transient";
+    }
     return Services.prefs.getStringPref(CONFIG.AI_EXISTING_BEHAVIOR_PREF, "always-add");
   } catch {
     return "always-add";

--- a/modules/tabs.mjs
+++ b/modules/tabs.mjs
@@ -32,15 +32,16 @@ export const getHostname = (url) => {
 
 // ─── Page snippet for AI classification context ──────────────────────────────
 //
-// Fetches a tab's URL and parses out a short summary from <meta name="description">
-// (or og:description / twitter:description). Gives the AI classifier real semantic
-// context for niche sites whose hostnames + titles alone aren't enough.
+// Fetches a tab's URL and extracts a structured signal block for the AI
+// classifier: page type (article/video/product/profile/...), site brand,
+// main heading, and description. The page TYPE is the strongest signal for
+// Arc-style intent-driven groupings ("Articles I'm reading" vs "Shopping").
 //
 // Fetches happen from chrome-privileged code with the user's cookie jar
 // (credentials: "include"), so authed pages return the real content rather
 // than a login wall. CORS doesn't apply at chrome scope.
 
-const SNIPPET_MAX_CHARS = 200;
+const SNIPPET_MAX_CHARS = 400;
 const SNIPPET_FETCH_TIMEOUT_MS = 3000;
 
 // Minimal HTML entity decoder — covers the entities that appear in meta tags.
@@ -68,13 +69,39 @@ const extractMetaContent = (html, name) => {
   return "";
 };
 
+// First <h1> — usually the page's main topic. Strip any nested tags from the
+// captured content. Returns "" if no h1 present (e.g. SPAs that hydrate later,
+// or sites that use h1 for the site logo / navigation only).
+const extractFirstH1 = (html) => {
+  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (!m?.[1]) return "";
+  return decodeHtmlEntities(m[1].replace(/<[^>]+>/g, "")).replace(/\s+/g, " ").trim();
+};
+
+// Pull a structured signal block instead of just the meta description. Each
+// element is tagged ([type: ...], [site: ...], [topic: ...]) so the LLM can
+// see them as distinct features rather than one blurry sentence. Empty
+// strings drop out — small sites with no OG metadata still get whatever's
+// available.
 const extractSnippetFromHtml = (html) => {
   const desc =
     extractMetaContent(html, "description") ||
     extractMetaContent(html, "og:description") ||
     extractMetaContent(html, "twitter:description");
-  if (!desc) return "";
-  return desc.replace(/\s+/g, " ").slice(0, SNIPPET_MAX_CHARS).trim();
+  const ogType = extractMetaContent(html, "og:type");
+  const ogSiteName = extractMetaContent(html, "og:site_name");
+  const h1 = extractFirstH1(html);
+
+  const parts = [];
+  if (ogType) parts.push(`[type: ${ogType.slice(0, 30)}]`);
+  if (ogSiteName) parts.push(`[site: ${ogSiteName.slice(0, 40)}]`);
+  if (h1 && h1.toLowerCase() !== desc.toLowerCase()) {
+    parts.push(`[topic: ${h1.slice(0, 100)}]`);
+  }
+  if (desc) parts.push(desc.slice(0, 250));
+
+  if (parts.length === 0) return "";
+  return parts.join(" ").replace(/\s+/g, " ").slice(0, SNIPPET_MAX_CHARS).trim();
 };
 
 // Returns "" on any failure (404, timeout, network error, non-HTML response,

--- a/modules/widget.mjs
+++ b/modules/widget.mjs
@@ -111,9 +111,62 @@ export const buildRulesEditor = (rules) => {
     return cell;
   };
 
+  // Drag-and-drop reorder. Pass 1 is first-match-wins, so the rules array
+  // order determines which group a domain lands in when multiple rules could
+  // claim it. Reordering here changes that priority AND the sidebar's group
+  // display order on next wand click.
+  //
+  // Drag state lives at the editor scope so all rows share it. The DOM
+  // indicator and the actual reorder target both read from `dragToIdx`, so
+  // what the user SEES is exactly what gets applied on drop — no recompute
+  // from clientY at drop-time (which would disagree if the cursor jittered
+  // in the moment between the final dragover and the mouseup).
+  let dragFromIdx = null;
+  let dragToIdx = null;
+
+  const clearDropIndicators = () => {
+    container.querySelectorAll(".zao-row-drop-before, .zao-row-drop-after")
+      .forEach((el) => el.classList.remove("zao-row-drop-before", "zao-row-drop-after"));
+  };
+
+  const reorderRules = (fromIdx, toIdx) => {
+    if (fromIdx === toIdx || fromIdx === toIdx - 1) return; // no-op moves
+    const [moved] = rules.splice(fromIdx, 1);
+    // Adjust toIdx down by one if we removed an item earlier in the list.
+    const adjustedTo = fromIdx < toIdx ? toIdx - 1 : toIdx;
+    rules.splice(adjustedTo, 0, moved);
+    persist();
+    render();
+  };
+
   const renderRow = (rule, idx) => {
     const row = h("div");
     row.className = "zao-row";
+    row.dataset.zaoIdx = String(idx);
+
+    // Drag-handle grip. Only this element is `draggable`, so the user must
+    // grab it explicitly — accidental drags from the name/domain inputs are
+    // impossible. Visual: a six-dot "⋮⋮" glyph.
+    const grip = h("div", { class: "zao-row-grip", text: "⋮⋮" });
+    grip.title = "Drag to reorder";
+    grip.setAttribute("draggable", "true");
+    grip.addEventListener("dragstart", (e) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/zao-rule-idx", String(idx));
+      dragFromIdx = idx;
+      dragToIdx = null;
+      // Drag the whole row visually (DataTransfer.setDragImage uses an
+      // element + offset). The grip alone would look strange detached.
+      try { e.dataTransfer.setDragImage(row, 12, row.offsetHeight / 2); } catch {}
+      row.classList.add("zao-row-dragging");
+    });
+    grip.addEventListener("dragend", () => {
+      row.classList.remove("zao-row-dragging");
+      clearDropIndicators();
+      dragFromIdx = null;
+      dragToIdx = null;
+    });
+    row.appendChild(grip);
 
     row.appendChild(renderColorCell(rule));
 
@@ -150,11 +203,74 @@ export const buildRulesEditor = (rules) => {
     return row;
   };
 
+  // Container-level dragover/drop. Some browsers don't fire dragover on the
+  // source element during a drag, so per-row listeners miss events when the
+  // cursor is still over the row being dragged. Listening at the container
+  // covers all rows uniformly — we hit-test the cursor's clientY against
+  // each row's bounding rect to figure out where the drop would land.
+  if (!container._zaoContainerDragListenersInstalled) {
+    container._zaoContainerDragListenersInstalled = true;
+    container.addEventListener("dragover", (e) => {
+      if (!e.dataTransfer.types.includes("text/zao-rule-idx")) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rows = Array.from(container.querySelectorAll(".zao-row"));
+      if (rows.length === 0) return;
+      // Find the row whose vertical range contains the cursor. If the cursor
+      // is above the first row, target index 0 / top half. If below the last
+      // row, target the last row's bottom half.
+      let targetRow = null;
+      let targetIdx = -1;
+      let above = true;
+      const firstRect = rows[0].getBoundingClientRect();
+      const lastRect = rows[rows.length - 1].getBoundingClientRect();
+      if (e.clientY < firstRect.top) {
+        targetRow = rows[0];
+        targetIdx = 0;
+        above = true;
+      } else if (e.clientY > lastRect.bottom) {
+        targetRow = rows[rows.length - 1];
+        targetIdx = rows.length - 1;
+        above = false;
+      } else {
+        for (let i = 0; i < rows.length; i++) {
+          const r = rows[i].getBoundingClientRect();
+          if (e.clientY >= r.top && e.clientY <= r.bottom) {
+            targetRow = rows[i];
+            targetIdx = i;
+            above = (e.clientY - r.top) < r.height / 2;
+            break;
+          }
+        }
+      }
+      if (!targetRow) return;
+      const newToIdx = above ? targetIdx : targetIdx + 1;
+      if (dragToIdx === newToIdx) return; // no DOM update needed
+      dragToIdx = newToIdx;
+      clearDropIndicators();
+      targetRow.classList.toggle("zao-row-drop-before", above);
+      targetRow.classList.toggle("zao-row-drop-after", !above);
+    });
+    container.addEventListener("drop", (e) => {
+      const fromStr = e.dataTransfer.getData("text/zao-rule-idx");
+      if (!fromStr) return;
+      e.preventDefault();
+      const fromIdx = parseInt(fromStr, 10);
+      const toIdx = dragToIdx;
+      clearDropIndicators();
+      dragFromIdx = null;
+      dragToIdx = null;
+      if (toIdx === null) return;
+      reorderRules(fromIdx, toIdx);
+    });
+  }
+
   render = () => {
     container.replaceChildren();
 
     const header = h("div");
     header.className = "zao-header";
+    header.appendChild(h("div")); // grip column (no label)
     header.appendChild(h("div")); // color column (no label)
     const c1 = h("div");
     c1.textContent = "Category";
@@ -189,11 +305,15 @@ export const buildRulesEditor = (rules) => {
     container.appendChild(addRow);
   };
 
-  // Refresh widget state from the pref. Called by both the pref observer and the
-  // dialog-open watcher to pick up external changes (e.g. via the tab right-click submenu, AI Pass 2 grow, or Backup Import).
+  // Refresh widget state from the pref. Called by both the pref observer and
+  // the dialog-open watcher to pick up external changes (e.g. via the tab
+  // right-click submenu, AI Pass 2 grow, or Backup Import). Passes
+  // `keepIncomplete: true` so a blank row the user just added (and which
+  // persists to disk as `{name:"", domains:[]}`) survives the round-trip
+  // and continues to appear in the editor across browser restarts.
   const refreshFromPref = (reason) => {
     if (!container.isConnected) return;
-    const fresh = readRulesPref();
+    const fresh = readRulesPref({ keepIncomplete: true });
     if (!fresh) return;
     if (JSON.stringify(fresh) === JSON.stringify(rules)) return;
     console.log(`${LOG} widget refresh (${reason}): ${rules.length} → ${fresh.length} rule(s)`);
@@ -380,7 +500,9 @@ export const buildBackupRestoreSection = () => {
   exportBtn.title = "Download current rules + skip-domains as a JSON file";
   exportBtn.addEventListener("click", async () => {
     const payload = {
-      rules: readRulesPref() || [],
+      // keepIncomplete: true so a user's in-progress rules are included in
+      // the backup — otherwise restoring would silently drop them.
+      rules: readRulesPref({ keepIncomplete: true }) || [],
       skipDomains: readSkipDomainsPref() || [],
     };
     const json = JSON.stringify(payload, null, 2);
@@ -503,7 +625,10 @@ export const buildBackupRestoreSection = () => {
         }
 
         const current = {
-          rules: (readRulesPref() || []).length,
+          // Match the widget's view (includes in-progress rules) so the
+          // "N → M" confirmation reflects what the user actually sees in
+          // the editor, not the filtered wand-click count.
+          rules: (readRulesPref({ keepIncomplete: true }) || []).length,
           skip: (readSkipDomainsPref() || []).length,
         };
         const summaryLines = [];

--- a/preferences.json
+++ b/preferences.json
@@ -84,5 +84,11 @@
     "label": "Keep Ollama model warm — preloads at browser start and keeps it loaded between clicks (faster tidy clicks; uses VRAM continuously)",
     "property": "extensions.zen-auto-organize.ai-ollama-warmup",
     "defaultValue": true
+  },
+  {
+    "type": "string",
+    "label": "Local AI batch size (only used when >75 unmatched tabs; smaller = gentler on CPU, larger = faster)",
+    "property": "extensions.zen-auto-organize.ai-local-batch-size",
+    "defaultValue": "30"
   }
 ]

--- a/theme.json
+++ b/theme.json
@@ -20,7 +20,7 @@
   "image": "https://raw.githubusercontent.com/flantig/Zen-Tab-Wand/main/image.png",
   "author": "franklinl",
   "ai": "yes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "preferences": "preferences.json",
   "tags": [
     "Tabs",
@@ -30,6 +30,6 @@
     "Ollama"
   ],
   "createdAt": "2026-05-15",
-  "updatedAt": "2026-05-21",
+  "updatedAt": "2026-06-01",
   "fork": ["zen"]
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -2,6 +2,21 @@
    Borders/backgrounds are derived from currentColor via color-mix so the
    widget adapts to whatever theme Zen is running. */
 
+/* --- Tab-group collapse fix.
+   Firefox's MozTabbrowserTabGroup sets `aria-hidden="true"` on non-selected
+   tabs when the group is collapsed, but leaves the visual hiding to CSS.
+   Firefox's standard horizontal tab strip ships that CSS; Zen's vertical
+   sidebar tabs don't (see zen-browser/desktop#11134, #11739). So clicking
+   the group chevron toggles `collapsed` but the tabs stay visible.
+   This rule hides them as users expect — selected tab still shows.
+
+   Note: Zen toggles `collapsed=""` (empty-string boolean attribute), NOT
+   `collapsed="true"`. The `[collapsed]` selector matches attribute *presence*,
+   which is the right shape for HTML boolean attributes regardless of value. */
+tab-group[collapsed] tab[aria-hidden="true"] {
+  display: none !important;
+}
+
 /* --- Look & Feel: minimal mode for rule-matched tab-groups.
    Overrides Zen's per-group color custom properties with values derived from
    the toolbar / urlbar so groups blend into the chrome instead of standing out. */
@@ -78,10 +93,47 @@ tab-group.zao-minimal {
 .zao-row,
 .zao-add-row {
   display: grid;
-  grid-template-columns: 28px 180px 1fr 28px;
+  /* grip | color | category | domains | remove */
+  grid-template-columns: 20px 28px 180px 1fr 28px;
   gap: 10px;
   padding: 8px 12px;
   align-items: center;
+}
+
+/* --- Drag-handle grip for reordering rules.
+   Only this element is `draggable`; the rest of the row stays clickable for
+   editing inputs / pills without triggering a drag. */
+.zao-row-grip {
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+  font-size: 14px;
+  line-height: 1;
+  letter-spacing: -3px;
+  text-align: center;
+  opacity: 0.35;
+  transition: opacity 120ms;
+}
+.zao-row-grip:hover {
+  opacity: 0.85;
+}
+.zao-row-grip:active,
+.zao-row.zao-row-dragging .zao-row-grip {
+  cursor: grabbing;
+}
+.zao-row.zao-row-dragging {
+  opacity: 0.45;
+}
+
+/* Drop indicators — thin colored bar at the top/bottom edge of the hovered
+   row while a drag is in progress. Uses currentColor so it picks up the
+   user's theme. Inset box-shadow offset is OPPOSITE-edge-relative: positive
+   Y draws at the top edge, negative Y at the bottom edge. */
+.zao-row.zao-row-drop-before {
+  box-shadow: 0 2px 0 0 color-mix(in srgb, currentColor 60%, transparent) inset;
+}
+.zao-row.zao-row-drop-after {
+  box-shadow: 0 -2px 0 0 color-mix(in srgb, currentColor 60%, transparent) inset;
 }
 
 /* Skip-domains editor — a single pill row beneath the "Skip Domains" Sine
@@ -429,6 +481,88 @@ dialog.zao-preview-dialog[open] {
 }
 dialog.zao-preview-dialog::backdrop {
   background: rgba(0, 0, 0, 0.45);
+}
+
+/* First-time Local AI warning modal. Single-button countdown-acknowledge
+   pattern: the button label starts as "3  I Understand" and counts down to
+   "I Understand" over 3 seconds, only becoming clickable when the countdown
+   completes. Solid (non-translucent) background regardless of Windows Mica
+   theming. */
+dialog.zao-warning-dialog {
+  padding: 22px 26px;
+  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  border-radius: 12px;
+  max-width: 460px;
+  width: min(460px, 92vw);
+  background: Canvas;
+  color: CanvasText;
+  box-shadow: 0 14px 48px rgba(0, 0, 0, 0.35);
+  font-size: 13px;
+  line-height: 1.5;
+}
+dialog.zao-warning-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+}
+.zao-warning-title {
+  margin: 0 0 12px 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.zao-warning-dialog p {
+  margin: 0 0 10px 0;
+}
+.zao-warning-lead {
+  font-size: 13px;
+  opacity: 0.85;
+  margin-bottom: 14px;
+}
+.zao-warning-list {
+  list-style: none;
+  margin: 0 0 18px 0;
+  padding: 0;
+}
+.zao-warning-list li {
+  padding: 8px 12px;
+  margin: 6px 0;
+  background: color-mix(in srgb, currentColor 5%, transparent);
+  border-left: 3px solid color-mix(in srgb, currentColor 25%, transparent);
+  border-radius: 4px;
+  line-height: 1.45;
+}
+.zao-warning-list strong {
+  font-weight: 600;
+}
+.zao-warning-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+.zao-warning-confirm {
+  appearance: none;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  color: inherit;
+  border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+  border-radius: 7px;
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+.zao-warning-confirm:not([disabled]):hover {
+  background: color-mix(in srgb, currentColor 18%, transparent);
+}
+.zao-warning-confirm[disabled] {
+  opacity: 0.55;
+  cursor: default;
+}
+.zao-warning-link {
+  color: LinkText;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.zao-warning-link:hover {
+  filter: brightness(1.15);
 }
 
 .zao-preview-header {


### PR DESCRIPTION
- AI engines:
  - Local built-in firefox dropdown is the following: Auto-add (should sort + grow rules), Transient (sort, rules untouched), and Fresh (NEW, cluster everything into hostname-named groups).
  - Ollama merges duplicate-sounding groups it just made (Communication
    Apps + Communication Tools become one group)
  - Ollama no longer dumps unrelated tabs into a generic existing group
    like "Utils"
  - Tabs you've already organized into a group won't get pulled into a
    brand-new AI group, only into other existing ones
  - Both engines now look at the page itself (description, headings,
    page type), not just the URL

- Settings:
  - The new-group dropdown only shows options that make sense for the
    engine you picked
  - Adjustable Local AI batch size
  - First-time warning when you pick each engine

- Tab UX:
  - Right-click a tab-group to dissolve it back into ungrouped tabs
  - Right-click a tab for an 'Add to Rule...' submenu that grows an
    existing rule
  - Collapsed groups stay collapsed after restarting the browser
  - When the wand sorts a tab into a collapsed group, the group stays
    closed and the new tab is hidden inside

- Performance:
  - Faster batched run for workspaces with more than 75 unmatched tabs
  - Confirmation prompt before running on more than 500 tabs

- Fixes:
  - Local AI recovers automatically when its connection drops between
    clicks
  - Browser pages (about:*, chrome://) no longer get bundled together
  - Empty rules you were drafting survive a browser restart
  - Drop indicator in the settings table points to the right spot
  - Much quieter console output during normal use
